### PR TITLE
Feature/pnorris/#2 add rrtmg to obio exports

### DIFF
--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -382,7 +382,7 @@ contains
     ! Decide if should make OBIO exports
     if (USE_RRTMG) then
        call ESMF_ConfigGetAttribute(CF, RRTMG_TO_OBIO, LABEL='RRTMG_TO_OBIO:', &
-          DEFAULT=.TRUE., __RC__)
+          DEFAULT=.FALSE., __RC__)
     else
        RRTMG_TO_OBIO = .FALSE.
     end if
@@ -1717,7 +1717,7 @@ contains
     ! Decide if should make OBIO exports
     if (USE_RRTMG) then
        call MAPL_GetResource( MAPL, RRTMG_TO_OBIO, LABEL='RRTMG_TO_OBIO:', & 
-          DEFAULT=.TRUE., __RC__)
+          DEFAULT=.FALSE., __RC__)
     else
        RRTMG_TO_OBIO = .FALSE.
     end if

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -5339,9 +5339,9 @@ contains
                   rwvn2 = wavenum2(jb)
                   rfirst = .false.
 
-                  ! Now find which OBIO bands it contributes to. OBIO bands are in
-                  ! increasing wavelength, decreasing wavenumber, so this loop is
-                  ! in increasing wavenumber
+                  ! Now find which OBIO bands the RRTMG band contributes to. OBIO bands
+                  ! are in increasing wavelength, decreasing wavenumber, so this loop is
+                  ! in increasing wavenumber.
                   do kb = kb_start,1,-1
 
                      ! OBIO band lower wavenumber limit
@@ -5374,11 +5374,8 @@ contains
 
                      ! now there is some overlap between the RRTMG and OBIO bands ...
 
-                     ! accumulate assuming constant energy spread across each RRTMG band
+                     ! accumulate assuming constant energy spread across each RRTMG band, rfrac in (0,1]
                      rfrac = (min(rwvn2,owvn2)-max(rwvn1,owvn1)) / (rwvn2 - rwvn1)
-                     _ASSERT(min(rwvn2,owvn2)-max(rwvn1,owvn1) > 0.,'temp 1')
-                     _ASSERT(rwvn2-rwvn1 > 0.,                      'temp 2')
-                     _ASSERT(rfrac > 0. .and. rfrac < 1.,           'temp 3')
                      if (associated(DROBIO)) DROBIO (:,:,kb) = DROBIO (:,:,kb) + DRBANDN (:,:,ib) * rfrac
                      if (associated(DFOBIO)) DFOBIO (:,:,kb) = DFOBIO (:,:,kb) + DFBANDN (:,:,ib) * rfrac
 


### PR DESCRIPTION
This PR achieves two things:
1. Under RRTMG the exports FSWBAND[NA] were previously MAPL_UNDEF because there was no facility in RRTMG to calculate them yet. This facility is now added. Clearly no one has been using these exports, but it is good to be able to provide them. This is non-zero-diff only in the sense that FSWBAND[NA] now have realistic values for RRTMG, but zero-diff effectively, since no one was using them yet.
2. RRTMG can now provide two new Exports DROBIO and DFOBIO. These are HorzOnly exports but with an Ungridded dimension of size 33, the number of OBIO bands. They are the surface downwelling direct and diffuse fluxes (all-sky, with aerosol) in the 33 bands used by ORadBioGC. They are added to support future connection to ORadBioGC (currently been worked on). The necessary internals and calculations are only included if 'RRTMG_TO_OBIO: .TRUE.' appears in AGCM.rc and if RRTMG SW is being run. So zero-diff in the sense that two new exports are added.
Neither change has any affect on any other export nor any significant affect on SOLAR timing.