### PR TITLE
Feature/pnorris/#9 add obio exports for chou suarez as well

### DIFF
--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -4292,7 +4292,9 @@ contains
 
       ! We will do the conversion from SOLAR to OBIO bands in wavenumber [cm^-1],
       ! since photon energy \propto wavenumber, where wavenumber \def 1 / wavelength.
-      real, parameter :: OBIO_bands_wavenum (2,NB_OBIO) = 1.e7 / OBIO_bands_nm
+      ! The wavenumber bounds must clearly be swapped from the wavelength bounds
+      ! because wavenumber is the inverse of wavelength.
+      real, parameter :: OBIO_bands_wavenum (2,NB_OBIO) = 1.e7 / OBIO_bands_nm(2:1:-1,:)
 
       ! CHOU bands (start,finish) in [nm]
       real, parameter :: CHOU_bands_nm (2,NB_CHOU) = reshape([ &
@@ -5044,8 +5046,8 @@ contains
                ! Source CHOU_bands_nm (2,NB_CHOU) is ordered in increasing waveLENGTH.
                ! See CHOU_bands_nm declaration for note about band 2a/b.
 
-               ! load Chou-Suarez bands (2,NB_CHOU) [cm^-1]
-               ! flip waveLENGTH bounds to waveNUMBER bounds
+               ! Load Chou-Suarez bands (2,NB_CHOU) [cm^-1].
+               ! Flip waveLENGTH bounds to waveNUMBER bounds.
                SOLAR_bands_wavenum (1,:) = 1.e7 / CHOU_bands_nm(2,:)
                SOLAR_bands_wavenum (2,:) = 1.e7 / CHOU_bands_nm(1,:)
 
@@ -5068,6 +5070,7 @@ contains
                ib = SOLAR_band_number_in_wvn_order(jb)
 
                ! SOLAR band (swvn1,swvn2)
+               ! Note: check SOLAR band continuity before updating swvn2
                swvn1 = SOLAR_bands_wavenum(1,ib)
                if (.not.sfirst) then
                   _ASSERT(swvn1 == swvn2, 'SOLAR bands not complete and unique!')
@@ -5080,19 +5083,15 @@ contains
                ! in increasing wavenumber.
                do kb = kb_start,1,-1
 
-                  ! OBIO band lower wavenumber limit
-                  ! (1&2 indicies on RHS were defined for wavelength ordering)
-                  owvn1 = OBIO_bands_wavenum(2,kb)
-
-                  ! check OBIO band continuity before updating owvn2
-                  if (.not. ofirst) then
+                  ! OBIO band (owvn1,owvn2)
+                  ! Note: check OBIO band continuity before updating owvn2
+                  owvn1 = OBIO_bands_wavenum(1,kb)
+                  if (.not.ofirst) then
                      if (kb .ne. kb_used_last) then
                         _ASSERT(owvn1 == owvn2, 'OBIO bands not complete and unique!')
                      end if
                   end if
-
-                  ! OBIO band upper wavenumber limit
-                  owvn2 = OBIO_bands_wavenum(1,kb)
+                  owvn2 = OBIO_bands_wavenum(2,kb)
                   kb_used_last = kb
                   ofirst = .false.
 

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -3546,8 +3546,10 @@ contains
       end do
       ! surface downwelling direct and diffuse fluxes in bands
       if (SOLAR_TO_OBIO .and. .not. NO_AERO) then
-        DRBAND(:,ib) = real(bnd_flux_dir_allsky(:,LM+1,ib))
-        DFBAND(:,ib) = real(bnd_flux_dn_allsky (:,LM+1,ib) - bnd_flux_dir_allsky(:,LM+1,ib))
+         do ib = 1, nbnd
+            DRBAND(:,ib) = real(bnd_flux_dir_allsky(:,LM+1,ib))
+            DFBAND(:,ib) = real(bnd_flux_dn_allsky (:,LM+1,ib) - bnd_flux_dir_allsky(:,LM+1,ib))
+         end do
       endif
       ! surface direct and diffuse downward in super-bands
       ! for *diffuse* downward must subtract direct (downward) from total downward

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -4313,7 +4313,7 @@ contains
 
       ! loaded later
       real :: SOLAR_bands_wavenum (2,NUM_BANDS_SOLAR)  ! [cm^-1]
-      integer :: SOLAR_bands_order (NUM_BANDS_SOLAR)
+      integer :: SOLAR_band_number_in_wvn_order (NUM_BANDS_SOLAR)
 
       real :: swvn1, swvn2, owvn1, owvn2, sfrac
       integer :: iseg, ibbeg, ibend, jb, kb, kb_start, kb_used_last
@@ -5021,7 +5021,7 @@ contains
                SOLAR_bands_wavenum = k_dist%get_band_lims_wavenumber()
 
                ! RRTMGP bands are already ordered in increasing wavenumber
-               SOLAR_bands_order = [(i, i=1,NUM_BANDS_SOLAR)]
+               SOLAR_band_number_in_wvn_order = [(i, i=1,NUM_BANDS_SOLAR)]
 
             elseif (USE_RRTMG) then 
 
@@ -5036,20 +5036,21 @@ contains
                SOLAR_bands_wavenum (2,:) = wavenum2(jpb1:jpb2)
 
                ! RRTMG band 14 comes before band 1 in increasing wavenumber
-               SOLAR_bands_order(1) = 14
-               SOLAR_bands_order(2:14) = [(i, i=1,13)]
+               SOLAR_band_number_in_wvn_order(1) = 14
+               SOLAR_band_number_in_wvn_order(2:14) = [(i, i=1,13)]
 
             else if (USE_CHOU) then
 
-               ! Source CHOU_bands_nm (2,NB_CHOU) is, ordered in increasing waveLENGTH.
+               ! Source CHOU_bands_nm (2,NB_CHOU) is ordered in increasing waveLENGTH.
                ! See CHOU_bands_nm declaration for note about band 2a/b.
 
-               ! load Chou-Suarez bands (2,NB_CHOU) [cm^-1] in increasing waveNUMBER
-               SOLAR_bands_wavenum (1,:) = 1.e7 / CHOU_bands_nm(2,NUM_BANDS_SOLAR:1:-1)
-               SOLAR_bands_wavenum (2,:) = 1.e7 / CHOU_bands_nm(1,NUM_BANDS_SOLAR:1:-1)
+               ! load Chou-Suarez bands (2,NB_CHOU) [cm^-1]
+               ! flip waveLENGTH bounds to waveNUMBER bounds
+               SOLAR_bands_wavenum (1,:) = 1.e7 / CHOU_bands_nm(2,:)
+               SOLAR_bands_wavenum (2,:) = 1.e7 / CHOU_bands_nm(1,:)
 
-               ! Chou-Suarez bands are now ordered in increasing wavenumber
-               SOLAR_bands_order = [(i, i=1,NUM_BANDS_SOLAR)]
+               ! Specify sorting of Chou-Suarez bands in increasing waveNUMBER
+               SOLAR_band_number_in_wvn_order = [(i, i=NUM_BANDS_SOLAR,1,-1)]
 
             endif
 
@@ -5064,7 +5065,7 @@ contains
             ofirst = .true.
             kb_start = NB_OBIO
             do jb = 1,NUM_BANDS_SOLAR
-               ib = SOLAR_bands_order(jb)
+               ib = SOLAR_band_number_in_wvn_order(jb)
 
                ! SOLAR band (swvn1,swvn2)
                swvn1 = SOLAR_bands_wavenum(1,ib)


### PR DESCRIPTION
This is an expansion of a previous PR#3 that enabled producing of OBIO surface solar downwelling direct and diffuse fluxes on OBIO bands. The previous PR worked for RRTMG only. This PR expands the facility to all three radiation codes. It is activated by putting SOLAR_TO_OBIO: .TRUE. in AGCM.rc and then associating the solar export fields DROBIO and DFOBIO either by exporting them in history or adding future connectivity to the OradBioGC. It is off by default and therefore zero-diff. Even if it is on, it is effectively zero-diff ... it only potentially produces two currently unused new exports, now for RRTMGP and Chou-Suarez as well as for RRTMG (PR#3).