### PR TITLE
pmn: use selectable tmin_OK

### DIFF
--- a/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
+++ b/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
@@ -1466,7 +1466,7 @@ contains
    real(wp) :: press_ref_min, ptop
    real(wp) ::  temp_ref_min, tmin
    real(wp), parameter :: ptop_increase_OK_fraction = 0.01_wp
-   real(wp), parameter :: tmin_increase_OK_Kelvin   = 10.0_wp
+   real(wp) :: tmin_increase_OK_Kelvin
 
    ! block size for efficient column processing (set from resource file)
    integer :: rrtmgp_blockSize
@@ -1952,6 +1952,9 @@ contains
       tmin = minval(t_lay)
       if (temp_ref_min > tmin) then
         ! allow a small increase of tmin
+        call MAPL_GetResource (MAPL, &
+           tmin_increase_OK_Kelvin, 'RRTMGP_LW_TMIN_INC_OK_K:', &
+           DEFAULT = 10., __RC__)
         if (temp_ref_min - tmin <= tmin_increase_OK_Kelvin) then
           where (t_lay < temp_ref_min) t_lay = temp_ref_min
         else

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -2144,7 +2144,7 @@ contains
       real(wp) :: press_ref_min, ptop
       real(wp) ::  temp_ref_min, tmin
       real(wp), parameter :: ptop_increase_OK_fraction = 0.01_wp
-      real(wp), parameter :: tmin_increase_OK_Kelvin   = 10.0_wp
+      real(wp) :: tmin_increase_OK_Kelvin
 
       ! block size for efficient column processing (set from resource file)
       integer :: rrtmgp_blockSize
@@ -3014,6 +3014,9 @@ contains
       tmin = minval(t_lay)
       if (temp_ref_min > tmin) then
         ! allow a small increase of tmin
+        call MAPL_GetResource (MAPL, &
+           tmin_increase_OK_Kelvin, 'RRTMGP_SW_TMIN_INC_OK_K:', &
+           DEFAULT = 10., __RC__)
         if (temp_ref_min - tmin <= tmin_increase_OK_Kelvin) then
           where (t_lay < temp_ref_min) t_lay = temp_ref_min
         else


### PR DESCRIPTION
A small PR that allows the user selectable leniency of minimum temperature for LUT violation. Put the following in AGCM.rc:
RRTMGP_LW_TMIN_INC_OK_K: 15.0
RRTMGP_SW_TMIN_INC_OK_K: 15.0
Here 15.0 is an example. The default for both is 10.0 Kelvin. 15.0 is more lenient than 10.0.
This change is non-zero-diff, but only if you are running RRTMGP.