### PR TITLE
Feature/pnorris/rrtmgp v1.7

### DIFF
--- a/GEOS_RadiationShared/RRTMGP_cmake/CMakeLists.txt
+++ b/GEOS_RadiationShared/RRTMGP_cmake/CMakeLists.txt
@@ -2,33 +2,34 @@ esma_set_this (OVERRIDE RRTMGP)
 
 # These are from RRTMGP
 set (RRTMGP_SRCS
-  rte/mo_rte_kind.F90
-  rte/mo_rte_config.F90
-  rte/mo_rte_util_array.F90
-  rte/kernels/mo_rte_solver_kernels.F90
-  rte/kernels/mo_optical_props_kernels.F90
-  rte/kernels/mo_fluxes_broadband_kernels.F90
-  rte/mo_optical_props.F90
-  rte/mo_source_functions.F90
-  rte/mo_fluxes.F90
-  rrtmgp/mo_rrtmgp_constants.F90
-  rrtmgp/mo_rrtmgp_util_string.F90
-  rrtmgp/mo_gas_optics.F90
-  rrtmgp/mo_gas_optics_rrtmgp.F90
-  rrtmgp/mo_gas_concentrations.F90
-  rrtmgp/kernels/mo_gas_optics_kernels.F90
+  rte-frontend/mo_rte_kind.F90
+  rte-frontend/mo_rte_config.F90
+  rte-frontend/mo_rte_util_array_validation.F90
+  rte-kernels/mo_rte_util_array.F90
+  rte-kernels/mo_rte_solver_kernels.F90
+  rte-kernels/mo_optical_props_kernels.F90
+  rte-kernels/mo_fluxes_broadband_kernels.F90
+  rte-frontend/mo_optical_props.F90
+  rte-frontend/mo_source_functions.F90
+  rte-frontend/mo_fluxes.F90
+  rte-frontend/mo_rte_lw.F90
+  rte-frontend/mo_rte_sw.F90
+  gas-optics/mo_gas_optics_constants.F90
+  gas-optics/mo_gas_optics_util_string.F90
+  gas-optics/mo_gas_concentrations.F90
+  gas-optics/mo_gas_optics.F90
+  rrtmgp-kernels/mo_gas_optics_rrtmgp_kernels.F90
+  rrtmgp-frontend/mo_gas_optics_rrtmgp.F90
+  rrtmgp-frontend/mo_cloud_optics_rrtmgp.F90
   extensions/mo_compute_bc.F90
   extensions/mo_fluxes_byband.F90
   extensions/mo_fluxes_bygpoint.F90
   extensions/mo_heating_rates.F90
   extensions/mo_rrtmgp_clr_all_sky.F90
-  extensions/cloud_optics/mo_cloud_optics.F90
-  extensions/cloud_optics/mo_cloud_sampling.F90
+  extensions/mo_cloud_sampling.F90
   examples/mo_simple_netcdf.F90
   examples/mo_load_coefficients.F90
   examples/all-sky/mo_load_cloud_coefficients.F90
-  rte/mo_rte_lw.F90
-  rte/mo_rte_sw.F90
   )
 
 esma_mepo_style(RRTMGP RRTMGP_rel_path REL_PATH ..)
@@ -77,3 +78,9 @@ if (MKL_FOUND)
 endif()
 
 set_target_properties (${this} PROPERTIES Fortran_MODULE_DIRECTORY ${include_${this}})
+
+# Option to enable RRTMGP single-precision
+option(RRTMGP_SINGLE_PRECISION "Use single precision for RRTMGP" OFF)
+if (RRTMGP_SINGLE_PRECISION)
+  target_compile_definitions(${this} PRIVATE RTE_USE_SP)
+endif()

--- a/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
+++ b/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
@@ -1861,8 +1861,8 @@ contains
 
       ! initialize k-distribution if not already done
       call MAPL_GetResource( &
-        MAPL, k_dist_file, "RRTMGP_DATA_LW:", &
-        DEFAULT='rrtmgp-data-lw.nc',__RC__)
+        MAPL, k_dist_file, "RRTMGP_GAS_LW:", &
+        DEFAULT='rrtmgp-gas-lw-g128.nc',__RC__)
       if (.not. rrtmgp_state%initialized) then
         ! gas_concs needed only to access required gas names
         call MAPL_TimerOn(MAPL,"---RRTMGP_IO_GAS",__RC__)
@@ -2171,8 +2171,8 @@ contains
         ! gets appropriate coefficients needed to calculate
         ! cloud optical properties from cloud physical properties
         call MAPL_GetResource( &
-          MAPL, cloud_optics_file, "RRTMGP_CLOUD_OPTICS_COEFFS_LW:", &
-          DEFAULT='rrtmgp-cloud-optics-coeffs-lw.nc', __RC__)
+          MAPL, cloud_optics_file, "RRTMGP_CLOUD_OPTICS_LW:", &
+          DEFAULT='rrtmgp-clouds-lw.nc', __RC__)
         call MAPL_GetResource( &
           MAPL, cloud_optics_type, "RRTMGP_CLOUD_OPTICS_TYPE_LW:", &
           DEFAULT='LUT', __RC__)

--- a/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
+++ b/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
@@ -1219,7 +1219,7 @@ contains
    ! RRTMGP module uses
    use mo_rte_kind,                only: wp
    use mo_gas_concentrations,      only: ty_gas_concs
-   use mo_cloud_optics,            only: ty_cloud_optics
+   use mo_cloud_optics_rrtmgp,     only: ty_cloud_optics_rrtmgp
    use mo_cloud_sampling,          only: draw_samples, &
                                          sampled_mask_max_ran, sampled_mask_exp_ran, &
                                          sampled_urand_gen_max_ran
@@ -1403,7 +1403,7 @@ contains
    ! derived types for interacting with RRTMGP
    type(ty_gas_optics_rrtmgp), pointer           :: k_dist
    type(ty_gas_concs)                            :: gas_concs, gas_concs_block
-   type(ty_cloud_optics)                         :: cloud_optics
+   type(ty_cloud_optics_rrtmgp)                  :: cloud_optics
    type(ty_source_func_lw)                       :: sources
    type(ty_fluxes_broadband)                     :: fluxes_clrsky, fluxes_clrnoa, &
                                                     fluxes_allsky, fluxes_allnoa

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -4578,8 +4578,8 @@ contains
 
       ! initialize k-distribution if not already done
       call MAPL_GetResource( &
-        MAPL, k_dist_file, "RRTMGP_DATA_SW:", &
-        DEFAULT='rrtmgp-data-sw.nc',__RC__)
+        MAPL, k_dist_file, "RRTMGP_GAS_SW:", &
+        DEFAULT='rrtmgp-gas-sw-g112.nc',__RC__)
       if (.not. rrtmgp_state%initialized) then
         ! gas_concs needed only to access required gas names
         call MAPL_TimerOn(MAPL,"--RRTMGP_IO_GAS",__RC__)
@@ -4773,8 +4773,8 @@ contains
       ! gets appropriate coefficients needed to calculate
       ! cloud optical properties from cloud physical properties
       call MAPL_GetResource( &
-        MAPL, cloud_optics_file, "RRTMGP_CLOUD_OPTICS_COEFFS_SW:", &
-        DEFAULT='rrtmgp-cloud-optics-coeffs-reordered-sw.nc', __RC__)
+        MAPL, cloud_optics_file, "RRTMGP_CLOUD_OPTICS_SW:", &
+        DEFAULT='rrtmgp-clouds-sw.nc', __RC__)
       call MAPL_GetResource( &
         MAPL, cloud_optics_type, "RRTMGP_CLOUD_OPTICS_TYPE_SW:", &
         DEFAULT='LUT', __RC__)

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -3288,7 +3288,7 @@ contains
       ! RRTMGP module uses
       use mo_rte_kind,                only: wp
       use mo_gas_concentrations,      only: ty_gas_concs
-      use mo_cloud_optics,            only: ty_cloud_optics
+      use mo_cloud_optics_rrtmgp,     only: ty_cloud_optics_rrtmgp
       use mo_cloud_sampling,          only: draw_samples, &
                                             sampled_mask_max_ran, sampled_mask_exp_ran, &
                                             sampled_urand_gen_max_ran
@@ -3478,7 +3478,7 @@ contains
       ! coefficients and cloud physical properties)
       type(ty_gas_optics_rrtmgp), pointer               :: k_dist
       type(ty_gas_concs)                                :: gas_concs, gas_concs_block
-      type(ty_cloud_optics)                             :: cloud_optics
+      type(ty_cloud_optics_rrtmgp)                      :: cloud_optics
       type(ty_fluxes_byband)                            :: fluxes_clrsky, fluxes_allsky
 
       ! PMN: my earlier RRTMGP implementations used cloud_props for liq and ice combined,


### PR DESCRIPTION
Upgrade to RRTMGP v1.7 from previous v1.6.
Needs @RRTMGP to be at v1.7.
This should be 0-diff for a default RRTMG run, but please check.
It will be non-0-diff for an RRTMGP run.
v1.7 has various improvements (see @RRTMG) including some numerics improvements.
Under v1.7 RRTMGP can now be run in Single Precision mode with the option below:
./parallel_build.csh -- -DRRTMGP_SINGLE_PRECISION=ON.
Whether this is faster is being investigated ... its likely a trade-off, since it will be less accurate than default double precision.
I have noticed around a -0.15W/m2 difference in global OSR in SP mode, but individual clouds can be -2 W/m2 or more. 
This must be matched with a corresponding PR in @GEOS_App, since I change some of the configuration names for RRTMGP in AGCM.rc.tmpl.