### PR TITLE
Update ESMF CMake target to ESMF::ESMF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,5 +10,5 @@ set (alldirs
 esma_add_library (${this}
   SRCS GEOS_RadiationGridComp.F90
   SUBCOMPONENTS ${alldirs}
-  DEPENDENCIES MAPL GEOS_Shared esmf)
+  DEPENDENCIES MAPL GEOS_Shared ESMF::ESMF)
 

--- a/GEOSsolar_GridComp/RRTMG/rrtmg_sw/gcm_model/src/CMakeLists.txt
+++ b/GEOSsolar_GridComp/RRTMG/rrtmg_sw/gcm_model/src/CMakeLists.txt
@@ -40,7 +40,7 @@ foreach (file ${k_g_srcs})
 endforeach ()
 
 esma_add_library (${this} SRCS ${srcs} ${k_g_srcs}
-  DEPENDENCIES GEOS_Shared MAPL RRTMG_SW_mods GEOS_RadiationShared esmf NetCDF::NetCDF_Fortran)
+  DEPENDENCIES GEOS_Shared MAPL RRTMG_SW_mods GEOS_RadiationShared ESMF::ESMF NetCDF::NetCDF_Fortran)
 
 if(ENABLE_SOLAR_RADVAL)
    target_compile_definitions(${this} PRIVATE SOLAR_RADVAL)


### PR DESCRIPTION
This PR updates the ESMF CMake target to `ESMF::ESMF` which is the
correct canonical target name for ESMF. This is necessary for Spack
compatibility. NOTE: This requires ESMF 8.6.1 or later.