### PR TITLE
Fix issue with COT calculations

### DIFF
--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -6382,17 +6382,40 @@ contains
       end if
 
       ! undef versions of cloud optical thicknesses
-      COTTP = merge(COTNTP/COTDTP, MAPL_UNDEF, COTDTP > 0. .and. COTDTP > 0.)
-      COTHP = merge(COTNHP/COTDHP, MAPL_UNDEF, COTDHP > 0. .and. COTDHP > 0.)
-      COTMP = merge(COTNMP/COTDMP, MAPL_UNDEF, COTDMP > 0. .and. COTDMP > 0.)
-      COTLP = merge(COTNLP/COTDLP, MAPL_UNDEF, COTDLP > 0. .and. COTDLP > 0.)
+      ! We cannot use a merge here because some compilers (e.g. Intel)
+      ! will will evaluate the first argument first and if both are
+      ! zero, it will return NaNs.
+      where (COTNTP > 0. .and. COTDTP > 0.)
+         COTTP = COTNTP/COTDTP
+      elsewhere
+         COTTP = MAPL_UNDEF
+      end where
+
+      where (COTNHP > 0. .and. COTDHP > 0.)
+         COTHP = COTNHP/COTDHP
+      elsewhere
+         COTHP = MAPL_UNDEF
+      end where
+
+      where (COTNMP > 0. .and. COTDMP > 0.)
+         COTMP = COTNMP/COTDMP
+      elsewhere
+         COTMP = MAPL_UNDEF
+      end where
+
+      where (COTNLP > 0. .and. COTDLP > 0.)
+         COTLP = COTNLP/COTDLP
+      elsewhere
+         COTLP = MAPL_UNDEF
+      end where
 
 #ifdef SOLAR_RADVAL
       ! zero versions of cloud optical thicknesses
-      TAUTP = merge(COTTP, 0., COTDTP > 0. .and. COTDTP > 0.)
-      TAUHP = merge(COTHP, 0., COTDHP > 0. .and. COTDHP > 0.)
-      TAUMP = merge(COTMP, 0., COTDMP > 0. .and. COTDMP > 0.)
-      TAULP = merge(COTLP, 0., COTDLP > 0. .and. COTDLP > 0.)
+      ! We can use merge() here because we cannot divide by zero
+      TAUTP = merge(COTTP, 0., COTNTP > 0. .and. COTDTP > 0.)
+      TAUHP = merge(COTHP, 0., COTNHP > 0. .and. COTDHP > 0.)
+      TAUMP = merge(COTMP, 0., COTNMP > 0. .and. COTDMP > 0.)
+      TAULP = merge(COTLP, 0., COTNLP > 0. .and. COTDLP > 0.)
 #endif
 
       ! fluxes


### PR DESCRIPTION
This is a bugfix found by @atrayano. In testing v12 with tighter optimization, he found `-fpe0` was being triggered by:

```fortran
      COTTP = merge(COTNTP/COTDTP, MAPL_UNDEF, COTDTP > 0. .and. COTDTP > 0.)
      COTHP = merge(COTNHP/COTDHP, MAPL_UNDEF, COTDHP > 0. .and. COTDHP > 0.)
      COTMP = merge(COTNMP/COTDMP, MAPL_UNDEF, COTDMP > 0. .and. COTDMP > 0.)
      COTLP = merge(COTNLP/COTDLP, MAPL_UNDEF, COTDLP > 0. .and. COTDLP > 0.)
```
The reason seems to be that it's possible both `COTNTP` and `COTDTP` could maybe both be zero. If so, Intel seems to evaluate that quotient before the `merge` mask and sees a NaN. So, for safety, we convert this to a `where` block.

But @atrayano also found another issue which is that the mask was mistaken. It says:
```fortran
COTDTP > 0. .and. COTDTP > 0.
```
but we believe that first one should be `COTNTP` not `CONDTP`. `N` not `D`. 

I'll mention our belated friend @dr0cloud in case he still monitors but we think this is a bug.

Also: not sure if zero-diff or not so I'll block until I can test.