### PR TITLE
v12: Convert Solar GC to use gFTL StringVector

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 # Anchors in case we need to override the defaults from the orb
-#baselibs_version: &baselibs_version v7.17.0
-#bcs_version: &bcs_version v11.4.0
+#baselibs_version: &baselibs_version v8.5.0
+#bcs_version: &bcs_version v12.0.0
 
 orbs:
-  ci: geos-esm/circleci-tools@2
+  ci: geos-esm/circleci-tools@5
 
 workflows:
   build-test:
@@ -17,11 +17,14 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [gfortran, ifort]
+              compiler: [gfortran, ifort, ifx]
           #baselibs_version: *baselibs_version
           repo: GEOSgcm
           checkout_fixture: true
-          mepodevelop: true
+          # V12 code uses a special branch for now.
+          fixture_branch: feature/sdrabenh/gcm_v12
+          # We comment out this as it will "undo" the fixture_branch
+          #mepodevelop: true
           persist_workspace: true # Needs to be true to run fv3/gcm experiment, costs extra
 
       # Run AMIP GCM (1 hour, no ExtData)
@@ -31,7 +34,7 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [gfortran, ifort]
+              compiler: [gfortran, ifort, ifx]
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm
@@ -45,7 +48,7 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [gfortran, ifort]
+              compiler: [ifort, ifx]
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ workflows:
             - docker-hub-creds
           matrix:
             parameters:
-              compiler: [ifort, ifx]
+              compiler: [ifort]
           requires:
             - build-GEOSgcm-on-<< matrix.compiler >>
           repo: GEOSgcm

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -3376,7 +3376,7 @@ contains
           call string_vec_iter%next()
        end do
 
-       if (.not.do_no_aero_calc)
+       if (.not. do_no_aero_calc) then
 
          call string_vec%clear()
 


### PR DESCRIPTION
Tests with `ifx` found it was segfaulting (for some reason) in this "array of strings" construct that was in the Solar GridComp. 

Even my cursory knowledge of gFTL thought "Hey, this looks like gFTL!". So with the help of @bena-nasa we have converted the code to use StringVector!

Initial tests seem to say it works...or at least doesn't *crash*. I need to do more tests on discover with ifort, gfortran, etc.

Note that this might not be the best gFTL code. Once @tclune is back, I'll have him give it a look-see.

ETA: Confirmed zero-diff with v12 and ifort 2021.13