### PR TITLE
Add protections on aer_props passed to RRTMGP

### DIFF
--- a/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
+++ b/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
@@ -2589,6 +2589,27 @@ contains
                 aer_props%ssa = 0._wp
                 aer_props%g   = 0._wp
               end where
+
+              ! Because RRTMGP is (currently) compiled at R8,
+              ! _wp is R8. Apparently with aggressive compiler
+              ! flags using Intel, it's possible for, say,
+              ! aer_props%ssa to become slightly greater than one
+              ! in the above renormalization. So, we add clamps
+              ! to the values based on the restrictions see in
+              ! RRTMGP/rte-frontend/mo_optical_props.F90
+              !
+              ! In testing, the values seen were like 1.00000011905028
+              ! so just slightly above one.
+
+              ! tau must be greater than 0.0
+              aer_props%tau = max(aer_props%tau, 0._wp)
+              ! ssa must be between 0.0 and 1.0
+              aer_props%ssa = max(min(aer_props%ssa, 1._wp), 0._wp)
+              ! g must be between -1.0 and 1.0
+              aer_props%g   = max(min(aer_props%g,   1._wp),-1._wp)
+
+            class default
+              TEST_('aerosol optical properties hardwired 2-stream for now')
           end select
         end if
 


### PR DESCRIPTION
Closes #55 

This PR adds protections on some aerosol properties passed to RRTMGP. Because RRTMGP is (currently) compiled at R8, _wp is R8. Apparently with aggressive compiler flags, it's possible for, say, aer_props%ssa to become slightly greater than one in the above renormalization. 

So, we add clamps to the values based on the restrictions seen in https://github.com/GEOS-ESM/rte-rrtmgp/blob/1163c8c608a341987c2647dfa540481688c064bc/rte-frontend/mo_optical_props.F90#L645-L652

In testing, the values seen were like 1.00000011905028 so just slightly above one.

I've labeled as non-zero-diff because, well, this could change answers.