### PR TITLE
v12: Update Intel Release build of RRTMGP

### DIFF
--- a/GEOS_RadiationShared/RRTMGP_cmake/CMakeLists.txt
+++ b/GEOS_RadiationShared/RRTMGP_cmake/CMakeLists.txt
@@ -66,13 +66,6 @@ esma_add_library(${this}
   SRCS ${SRCS}
   DEPENDENCIES NetCDF::NetCDF_Fortran)
 
-# Use of the GEOS Vectorized flags in RRTMGP caused a segfault leading to
-# line 726 of mo_gas_optics_kernels.F90. Moving to the "old" no-vect flags
-# allows RRTMGP to run again.
-if (CMAKE_Fortran_COMPILER_ID MATCHES Intel AND CMAKE_BUILD_TYPE MATCHES Release)
-  set (CMAKE_Fortran_FLAGS_RELEASE "${GEOS_Fortran_FLAGS_NOVECT}")
-endif ()
-
 if (MKL_FOUND)
   target_include_directories (${this} PRIVATE ${MKL_INCLUDE_DIRS})
 endif()


### PR DESCRIPTION
This PR updates the Intel Fortran build of RRTMGP. Should be taken with https://github.com/GEOS-ESM/ESMA_cmake/pull/425