### PR TITLE
v12: Support for no-MKL RRTMGP

### DIFF
--- a/GEOS_RadiationShared/RRTMGP_cmake/CMakeLists.txt
+++ b/GEOS_RadiationShared/RRTMGP_cmake/CMakeLists.txt
@@ -57,9 +57,12 @@ if (MKL_FOUND)
     rng/mo_rng_mklvsl.F90
     rng/mo_rng_mklvsl_plus.F90
     )
-
+  message(STATUS "MKL found. The mklvsl rng will be compiled.")
 else ()
-  ecbuild_warn("MKL was not found. The mklvsl rng will not be compiled. RRTMGP should not be used.")
+  list (APPEND SRCS
+    rng/mo_rng_mt19937.F90
+    )
+  message(STATUS "MKL not found. The mt19937 rng will be compiled.")
 endif()
 
 esma_add_library(${this}

--- a/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
+++ b/GEOSirrad_GridComp/GEOS_IrradGridComp.F90
@@ -1256,6 +1256,8 @@ contains
    !
    use MKL_VSL_TYPE
    use mo_rng_mklvsl_plus, only: ty_rng_mklvsl_plus
+#else
+   use mo_rng_mt19937, only: ty_rng_mt
 #endif
 
    ! for RRTMGP (use implicit inside RRTMG)
@@ -1459,6 +1461,8 @@ contains
    ! a column random number generator
 #ifdef HAVE_MKL
    type(ty_rng_mklvsl_plus) :: rng
+#else
+   type(ty_rng_mt) :: rng
 #endif
    integer, dimension(:), allocatable :: seeds
 
@@ -2647,7 +2651,6 @@ contains
 
           ! Generate McICA random numbers for block.
           ! Perhaps later this can be parallelized?
-#ifdef HAVE_MKL
           do isub = 1, ncols_block
             ! local 1d column index
             icol = colS + isub - 1
@@ -2658,8 +2661,12 @@ contains
             ! set word1 of key based on GLOBAL location
             ! 32-bits can hold all forseeable resolutions
             seeds(1) = (jBeg + J - 1) * IM_World + (iBeg + I - 1)
+#ifdef HAVE_MKL
             ! instantiate a random number stream for the column
             call rng%init(VSL_BRNG_PHILOX4X32X10,seeds)
+#else
+            call rng%init(seeds)
+#endif
             ! draw the random numbers for the column
             urand(:,:,isub) = reshape(rng%get_random(ngpt*LM),(/ngpt,LM/))
             if (gen_mro) then
@@ -2672,7 +2679,6 @@ contains
             ! free the rng
             call rng%end()
           end do
-#endif
 
           ! cloud sampling to gpoints
           select case (cloud_overlap_type)

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -3495,6 +3495,8 @@ contains
       !
       use MKL_VSL_TYPE
       use mo_rng_mklvsl_plus, only: ty_rng_mklvsl_plus
+#else
+      use mo_rng_mt19937, only: ty_rng_mt
 #endif
 
       ! for RRTMGP (use implicit inside RRTMG)
@@ -3733,6 +3735,8 @@ contains
       ! a column random number generator
 #ifdef HAVE_MKL
       type(ty_rng_mklvsl_plus) :: rng
+#else
+      type(ty_rng_mt) :: rng
 #endif
       integer, dimension(:), allocatable :: seeds
 
@@ -5470,7 +5474,6 @@ contains
 
         ! generate McICA random numbers for block
         ! Perhaps later this can be parallelized?
-#ifdef HAVE_MKL
         do isub = 1, ncols_block
           ! local 1d column index
           icol = colS + isub - 1
@@ -5478,8 +5481,12 @@ contains
           ! set word1 of key based on GLOBAL location
           ! 32-bits can hold all forseeable resolutions
           seeds(1) = nint(Jg1D(icol)) * IM_World + nint(Ig1D(icol))
+#ifdef HAVE_MKL
           ! instantiate a random number stream for the column
           call rng%init(VSL_BRNG_PHILOX4X32X10,seeds)
+#else
+          call rng%init(seeds)
+#endif
           ! draw the random numbers for the column
           urand(:,:,isub) = reshape(rng%get_random(ngpt*LM),(/ngpt,LM/))
           if (gen_mro) then
@@ -5492,7 +5499,6 @@ contains
           ! free the rng
           call rng%end()
         end do
-#endif
 
         ! cloud sampling to gpoints
         select case (cloud_overlap_type)


### PR DESCRIPTION
Closes #67 

This PR enables the use of RRTMGP on systems without MKL (e.g., macOS). It uses the Mersenne Twister code we seem to have.

Tested as works on macOS (with no MKL) and zero-diff on discover (with MKL).