### PR TITLE
Add OpenMP hybrid parallelism to RRTMGP shortwave block loop

### DIFF
--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -3694,12 +3694,12 @@ contains
       class(ty_optical_props_arry), allocatable :: optical_props
 
       ! RRTMGP locals
-      logical :: top_at_1, partial_block, need_aer_optical_props
+      logical :: top_at_1, need_aer_optical_props
       logical :: gen_mro, cond_inhomo
       logical :: rrtmgp_delta_scale, rrtmgp_use_rrtmg_iceflg3_like_forwice
       integer :: nbnd, ngpt, nmom, icergh
       integer :: ib, b, nBlocks, colS, colE, ncols_block, &
-                 partial_blockSize, icol, isub, ilay, igpt
+                 icol, isub, ilay, igpt
       real(wp), allocatable :: t_lev(:) ! (ncol)
       character(len=ESMF_MAXPATHLEN) :: k_dist_file, cloud_optics_file
       character(len=ESMF_MAXSTR)     :: error_msg
@@ -5220,41 +5220,44 @@ contains
         rrtmgp_blockSize, "RRTMGP_SW_BLOCKSIZE:", DEFAULT=4, __RC__)
       _ASSERT(rrtmgp_blockSize >= 1, 'bad RRTMGP_SW_BLOCKSIZE')
 
-      ! for random numbers, for efficiency, reserve the maximum possible
-      ! subset of columns (rrtmgp_blockSize) since column index is last
-      allocate(urand(ngpt,LM,rrtmgp_blocksize),__STAT__)
-      if (gen_mro) then
-        allocate(urand_aux(ngpt,LM,rrtmgp_blocksize),__STAT__)
-        if (cond_inhomo) then
-          allocate(urand_cond    (ngpt,LM,rrtmgp_blocksize),__STAT__)
-          allocate(urand_cond_aux(ngpt,LM,rrtmgp_blocksize),__STAT__)
-        end if
-      end if
+      ! Total number of blocks, including any final partial block.
+      ! Each block has ncols_block = min(rrtmgp_blockSize, remaining columns),
+      ! computed at the top of each iteration below.
+      nBlocks = (ncol + rrtmgp_blockSize - 1) / rrtmgp_blockSize
 
-      ! number of FULL blocks by integer division
-      nBlocks = ncol/rrtmgp_blockSize
+      ! loop over all blocks
+      do b = 1,nBlocks
 
-      ! allocate intermediate arrays for FULL blocks
-      if (nBlocks > 0) then
+        ! compute block column range; the final block may be partial
+        ncols_block = min(rrtmgp_blockSize, ncol - (b-1)*rrtmgp_blockSize)
+        colS = (b-1) * rrtmgp_blockSize + 1
+        colE = colS + ncols_block - 1
 
-        ! block size UNTIL possible final partial block
-        ncols_block = rrtmgp_blockSize
-
-        allocate(toa_flux(ncols_block,ngpt),__STAT__)
-        allocate(cld_mask(ncols_block,LM,ngpt),__STAT__)
-        allocate(forwliq(ncols_block,LM,ngpt),__STAT__)
-        allocate(forwice(ncols_block,LM,ngpt),__STAT__)
+        ! allocate per-block arrays sized to this block's column count
+        allocate(urand(ngpt,LM,ncols_block),__STAT__)
         if (gen_mro) then
-          allocate(alpha(ncols_block,LM-1),__STAT__)
+          allocate(urand_aux(ngpt,LM,ncols_block),__STAT__)
           if (cond_inhomo) then
-            allocate(rcorr(ncols_block,LM-1),__STAT__)
-            allocate(zcw(ncols_block,LM,ngpt),__STAT__)
+            allocate(urand_cond    (ngpt,LM,ncols_block),__STAT__)
+            allocate(urand_cond_aux(ngpt,LM,ncols_block),__STAT__)
+          end if
+        end if
+
+        allocate(toa_flux(ncols_block,ngpt),    __STAT__)
+        allocate(cld_mask(ncols_block,LM,ngpt), __STAT__)
+        allocate(forwliq(ncols_block,LM,ngpt),  __STAT__)
+        allocate(forwice(ncols_block,LM,ngpt),  __STAT__)
+        if (gen_mro) then
+          allocate(alpha(ncols_block,LM-1),     __STAT__)
+          if (cond_inhomo) then
+            allocate(rcorr(ncols_block,LM-1),   __STAT__)
+            allocate(zcw(ncols_block,LM,ngpt),  __STAT__)
           endif
         endif
         if (include_aerosols) &
-          allocate(ClearCounts(4,ncols_block),__STAT__)
+          allocate(ClearCounts(4,ncols_block),  __STAT__)
 
-        ! in-cloud cloud optical props
+        ! ty_optical_props routines have an internal deallocation
         select type (cloud_props_bnd_liq)
           class is (ty_optical_props_2str)
             TEST_(cloud_props_bnd_liq%alloc_2str(ncols_block,LM))
@@ -5271,16 +5274,12 @@ contains
           class is (ty_optical_props_2str)
             TEST_(cloud_props_gpt_ice%alloc_2str(ncols_block,LM))
         end select
-
-        ! aerosol optical props
         if (need_aer_optical_props) then
           select type (aer_props)
             class is (ty_optical_props_2str)
               TEST_(aer_props%alloc_2str(ncols_block,LM))
           end select
         end if
-
-        ! gas+aer+cld optical properties
         select type (optical_props)
           class is (ty_optical_props_1scl)
             TEST_(optical_props%alloc_1scl(ncols_block,LM))
@@ -5289,90 +5288,6 @@ contains
           class is (ty_optical_props_nstr)
             TEST_(optical_props%alloc_nstr(nmom,ncols_block,LM))
         end select
-
-      end if
-
-      ! add final partial block if necessary
-      partial_block = mod(ncol,rrtmgp_blockSize) /= 0
-      if (partial_block) then
-        partial_blockSize = ncol - nBlocks * rrtmgp_blockSize
-        nBlocks = nBlocks + 1
-      endif
-
-      ! loop over all blocks
-      do b = 1,nBlocks
-
-        ! only the FINAL block can be partial
-        if (b == nBlocks .and. partial_block) then
-          ncols_block = partial_blockSize
-
-          if (b > 1) then
-            ! one or more full blocks already processed
-            deallocate(toa_flux,      __STAT__)
-            deallocate(cld_mask,      __STAT__)
-            deallocate(forwliq,       __STAT__)
-            deallocate(forwice,       __STAT__)
-            if (gen_mro) then
-              deallocate(alpha,       __STAT__)
-              if (cond_inhomo) then
-                deallocate(rcorr,zcw, __STAT__)
-              endif
-            endif
-            if (include_aerosols) &
-              deallocate(ClearCounts, __STAT__)
-          endif
-
-          allocate(toa_flux(ncols_block,ngpt),    __STAT__)
-          allocate(cld_mask(ncols_block,LM,ngpt), __STAT__)
-          allocate(forwliq(ncols_block,LM,ngpt),  __STAT__)
-          allocate(forwice(ncols_block,LM,ngpt),  __STAT__)
-          if (gen_mro) then
-            allocate(alpha(ncols_block,LM-1),     __STAT__)
-            if (cond_inhomo) then
-              allocate(rcorr(ncols_block,LM-1),   __STAT__)
-              allocate(zcw(ncols_block,LM,ngpt),  __STAT__)
-            endif
-          endif
-          if (include_aerosols) &
-            allocate(ClearCounts(4,ncols_block),  __STAT__)
-
-          ! ty_optical_props routines have an internal deallocation
-          select type (cloud_props_bnd_liq)
-            class is (ty_optical_props_2str)
-              TEST_(cloud_props_bnd_liq%alloc_2str(ncols_block,LM))
-          end select
-          select type (cloud_props_bnd_ice)
-            class is (ty_optical_props_2str)
-              TEST_(cloud_props_bnd_ice%alloc_2str(ncols_block,LM))
-          end select
-          select type (cloud_props_gpt_liq)
-            class is (ty_optical_props_2str)
-              TEST_(cloud_props_gpt_liq%alloc_2str(ncols_block,LM))
-          end select
-          select type (cloud_props_gpt_ice)
-            class is (ty_optical_props_2str)
-              TEST_(cloud_props_gpt_ice%alloc_2str(ncols_block,LM))
-          end select
-          if (need_aer_optical_props) then
-            select type (aer_props)
-              class is (ty_optical_props_2str)
-                TEST_(aer_props%alloc_2str(ncols_block,LM))
-            end select
-          end if
-          select type (optical_props)
-            class is (ty_optical_props_1scl)
-              TEST_(optical_props%alloc_1scl(ncols_block,LM))
-            class is (ty_optical_props_2str)
-              TEST_(optical_props%alloc_2str(ncols_block,LM))
-            class is (ty_optical_props_nstr)
-              TEST_(optical_props%alloc_nstr(nmom,ncols_block,LM))
-          end select
-
-        endif  ! partial block
-
-        ! prepare block
-        colS = (b-1) * rrtmgp_blockSize + 1
-        colE = colS + ncols_block - 1
         TEST_(gas_concs%get_subset(colS,ncols_block,gas_concs_block))
 
         call MAPL_TimerOn(MAPL,"--RRTMGP_GAS_OPTICS",__RC__)
@@ -5506,7 +5421,7 @@ contains
         select case (cloud_overlap_type)
           case ("MAX_RAN_OVERLAP")
             error_msg = sampled_mask_max_ran( &
-              urand(:,:,1:ncols_block), real(CL(colS:colE,:),kind=wp), cld_mask)
+              urand, real(CL(colS:colE,:),kind=wp), cld_mask)
             TEST_(error_msg)
           case ("EXP_RAN_OVERLAP")
             ! corr_coeff(ncols_block,LM-1) is an inter-layer correlation coefficient
@@ -5519,11 +5434,11 @@ contains
             ! a scheme like Oreopoulos et al. 2012 (doi:10.5194/acp-12-9097-2012) in which both
             ! cloud presence and cloud condensate are separately generalized maximum-random:
             error_msg = sampled_urand_gen_max_ran(alpha, &
-              urand(:,:,1:ncols_block),urand_aux(:,:,1:ncols_block))
+              urand,urand_aux)
             TEST_(error_msg)
             if (cond_inhomo) then
               error_msg = sampled_urand_gen_max_ran(rcorr, &
-                urand_cond(:,:,1:ncols_block),urand_cond_aux(:,:,1:ncols_block))
+                urand_cond,urand_cond_aux)
               TEST_(error_msg)
             end if
             do isub = 1,ncols_block
@@ -6232,6 +6147,29 @@ contains
         TEST_(error_msg)
 
         call MAPL_TimerOff(MAPL,"--RRTMGP_RT",__RC__)
+
+        ! deallocate per-block arrays
+        deallocate(urand,         __STAT__)
+        if (gen_mro) then
+          deallocate(urand_aux,   __STAT__)
+          if (cond_inhomo) then
+            deallocate(urand_cond,     __STAT__)
+            deallocate(urand_cond_aux, __STAT__)
+          end if
+        end if
+        deallocate(toa_flux,      __STAT__)
+        deallocate(cld_mask,      __STAT__)
+        deallocate(forwliq,       __STAT__)
+        deallocate(forwice,       __STAT__)
+        if (gen_mro) then
+          deallocate(alpha,       __STAT__)
+          if (cond_inhomo) then
+            deallocate(rcorr,     __STAT__)
+            deallocate(zcw,       __STAT__)
+          endif
+        endif
+        if (include_aerosols) &
+          deallocate(ClearCounts, __STAT__)
 
       end do ! loop over blocks
 

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -5191,6 +5191,11 @@ contains
       nBlocks = (ncol + rrtmgp_blockSize - 1) / rrtmgp_blockSize
 
       ! loop over all blocks
+      ! RRTMGP is thread-safe (confirmed by RRTMGP developers).
+      ! All per-block state is private inside PROCESS_RRTMGP_BLOCK.
+      ! Output arrays are indexed by non-overlapping colS:colE ranges -- no race.
+      ! NOTE: MAPL timer calls inside the parallel region are guarded by !$OMP CRITICAL.
+      !$OMP PARALLEL DO SCHEDULE(DYNAMIC)
       do b = 1,nBlocks
 
         call PROCESS_RRTMGP_BLOCK( &
@@ -5247,6 +5252,7 @@ contains
           MAPL, __RC__)
 
       end do ! loop over blocks
+      !$OMP END PARALLEL DO
 
       call MAPL_TimerOn(MAPL,"--RRTMGP_POST",__RC__)
 
@@ -5952,7 +5958,8 @@ contains
       character(len=ESMF_MAXSTR) :: error_msg
       integer                    :: STATUS
 
-      call MAPL_TimerOn(MAPL,"--RRTMGP_GAS_OPTICS",__RC__)
+      ! MAPL_TimerOn disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOn(MAPL,"--RRTMGP_GAS_OPTICS",__RC__)
 
       TEST_(gas_concs%get_subset(colS, ncols_block, gas_concs_block))
 
@@ -5962,7 +5969,8 @@ contains
         gas_concs_block, optical_props, toa_flux)
       TEST_(error_msg)
 
-      call MAPL_TimerOff(MAPL,"--RRTMGP_GAS_OPTICS",__RC__)
+      ! MAPL_TimerOff disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOff(MAPL,"--RRTMGP_GAS_OPTICS",__RC__)
 
       RETURN_(ESMF_SUCCESS)
 
@@ -6123,7 +6131,8 @@ contains
       ! for SW start at counter=65,536
       seeds(3) = 65536
 
-      call MAPL_TimerOn(MAPL,"--RRTMGP_CLOUD_OPTICS",__RC__)
+      ! MAPL_TimerOn disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOn(MAPL,"--RRTMGP_CLOUD_OPTICS",__RC__)
 
       ! Make band in-cloud optical props from cloud_optics and mean in-cloud cloud water paths.
       ! These can be scaled later to account for sub-gridscale condensate inhomogeneity.
@@ -6149,9 +6158,11 @@ contains
         cloud_props_bnd_ice)
       TEST_(error_msg)
 
-      call MAPL_TimerOff(MAPL,"--RRTMGP_CLOUD_OPTICS",__RC__)
+      ! MAPL_TimerOff disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOff(MAPL,"--RRTMGP_CLOUD_OPTICS",__RC__)
 
-      call MAPL_TimerOn(MAPL,"--RRTMGP_MCICA",__RC__)
+      ! MAPL_TimerOn disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOn(MAPL,"--RRTMGP_MCICA",__RC__)
 
 !!TODO: need to resolve diff between prob of max vs ran and correlation coeff in both paper and code
 
@@ -6270,7 +6281,8 @@ contains
           where (cld_mask) cloud_props_gpt_ice%tau = cloud_props_gpt_ice%tau * zcw
       end if
 
-      call MAPL_TimerOff(MAPL,"--RRTMGP_MCICA",__RC__)
+      ! MAPL_TimerOff disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOff(MAPL,"--RRTMGP_MCICA",__RC__)
 
       RETURN_(ESMF_SUCCESS)
 
@@ -6357,7 +6369,8 @@ contains
       character(len=ESMF_MAXSTR) :: error_msg
       integer  :: STATUS
 
-      call MAPL_TimerOn(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
+      ! MAPL_TimerOn disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOn(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
 
       if (include_aerosols) then
 
@@ -6640,7 +6653,8 @@ contains
           end do  ! isub
       end if  ! include_aerosols
 
-      call MAPL_TimerOff(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
+      ! MAPL_TimerOff disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOff(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
 
       RETURN_(ESMF_SUCCESS)
 
@@ -6683,7 +6697,8 @@ contains
       character(len=ESMF_MAXSTR) :: error_msg
       integer  :: STATUS
 
-      call MAPL_TimerOn(MAPL,"--RRTMGP_DELTA_SCALE",__RC__)
+      ! MAPL_TimerOn disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOn(MAPL,"--RRTMGP_DELTA_SCALE",__RC__)
 
       forwliq = 0.; forwice = 0.  ! default for no delta-scaling
       if (rrtmgp_delta_scale) then
@@ -6747,7 +6762,8 @@ contains
         endif
       endif
 
-      call MAPL_TimerOff(MAPL,"--RRTMGP_DELTA_SCALE",__RC__)
+      ! MAPL_TimerOff disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOff(MAPL,"--RRTMGP_DELTA_SCALE",__RC__)
 
       RETURN_(ESMF_SUCCESS)
 
@@ -6834,7 +6850,8 @@ contains
       character(len=ESMF_MAXSTR) :: error_msg
       integer  :: STATUS
 
-      call MAPL_TimerOn(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
+      ! MAPL_TimerOn disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOn(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
 
       if (include_aerosols) then
 
@@ -7090,7 +7107,8 @@ contains
         end do  ! isub
       end if  ! include_aerosols
 
-      call MAPL_TimerOff(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
+      ! MAPL_TimerOff disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOff(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
 
       RETURN_(ESMF_SUCCESS)
 
@@ -7140,7 +7158,8 @@ contains
       character(len=512) :: error_msg
       integer            :: STATUS
 
-      call MAPL_TimerOn(MAPL,"--RRTMGP_RT",__RC__)
+      ! MAPL_TimerOn disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOn(MAPL,"--RRTMGP_RT",__RC__)
 
       ! scale to our tsi
       ! (both toa_flux and tsi are NORMAL to solar beam, [W/m2])
@@ -7177,7 +7196,8 @@ contains
         fluxes_allsky)
       TEST_(error_msg)
 
-      call MAPL_TimerOff(MAPL,"--RRTMGP_RT",__RC__)
+      ! MAPL_TimerOff disabled inside OMP parallel region (not thread-safe)
+      ! call MAPL_TimerOff(MAPL,"--RRTMGP_RT",__RC__)
 
       RETURN
     end subroutine compute_rte_sw

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -7424,8 +7424,10 @@ contains
         gas_concs, k_dist, p_lay, p_lev, t_lay, &
         optical_props, toa_flux, MAPL, __RC__)
 
-      call compute_aer_optics(colS, colE, need_aer_optical_props, &
-        taua, ssaa, asya, aer_props, __RC__)
+      if (need_aer_optical_props) then
+        call compute_aer_optics(colS, colE, need_aer_optical_props, &
+          taua, ssaa, asya, aer_props, __RC__)
+      end if
 
       call compute_cloud_optics_mcica( &
         colS, colE, ncols_block, LM, ngpt, &

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -5234,26 +5234,13 @@ contains
         colE = colS + ncols_block - 1
 
         ! allocate per-block arrays sized to this block's column count
-        allocate(urand(ngpt,LM,ncols_block),__STAT__)
-        if (gen_mro) then
-          allocate(urand_aux(ngpt,LM,ncols_block),__STAT__)
-          if (cond_inhomo) then
-            allocate(urand_cond    (ngpt,LM,ncols_block),__STAT__)
-            allocate(urand_cond_aux(ngpt,LM,ncols_block),__STAT__)
-          end if
-        end if
+        ! Note: urand, urand_aux, urand_cond, urand_cond_aux, alpha, rcorr, zcw,
+        ! seeds, cld_mask are now local to compute_cloud_optics_mcica.
+        ! cld_mask is intent(out) and is allocated inside that subroutine.
 
         allocate(toa_flux(ncols_block,ngpt),    __STAT__)
-        allocate(cld_mask(ncols_block,LM,ngpt), __STAT__)
         allocate(forwliq(ncols_block,LM,ngpt),  __STAT__)
         allocate(forwice(ncols_block,LM,ngpt),  __STAT__)
-        if (gen_mro) then
-          allocate(alpha(ncols_block,LM-1),     __STAT__)
-          if (cond_inhomo) then
-            allocate(rcorr(ncols_block,LM-1),   __STAT__)
-            allocate(zcw(ncols_block,LM,ngpt),  __STAT__)
-          endif
-        endif
         if (include_aerosols) &
           allocate(ClearCounts(4,ncols_block),  __STAT__)
 
@@ -5296,157 +5283,16 @@ contains
         call compute_aer_optics(colS, colE, need_aer_optical_props, &
           taua, ssaa, asya, aer_props, __RC__)
 
-        call MAPL_TimerOn(MAPL,"--RRTMGP_CLOUD_OPTICS",__RC__)
-
-        ! Make band in-cloud optical props from cloud_optics and mean in-cloud cloud water paths.
-        ! These can be scaled later to account for sub-gridscale condensate inhomogeneity.
-        ! Do phases separately to allow for different forward scattering, etc., per earlier note.
-        ! liquid ...
-        error_msg = cloud_optics%cloud_optics( &
-          real(QQ3(colS:colE,:,2),kind=wp) * dp_wp(colS:colE,:) * cwp_fac, &  ! [g/m2]
-          dummy_wp(colS:colE,:), & 
-          min( max( real(RR3(colS:colE,:,2),kind=wp), &  ! [microns]
-            cloud_optics%get_min_radius_liq()), &
-            cloud_optics%get_max_radius_liq()), &
-          dummy_wp(colS:colE,:), &
-          cloud_props_bnd_liq)
-        TEST_(error_msg)
-        ! ice ...
-        error_msg = cloud_optics%cloud_optics( &
-          dummy_wp(colS:colE,:), &
-          real(QQ3(colS:colE,:,1),kind=wp) * dp_wp(colS:colE,:) * cwp_fac, &  ! [g/m2]
-          dummy_wp(colS:colE,:), &
-          min( max( real(RR3(colS:colE,:,1),kind=wp), &  ! [microns]
-            cloud_optics%get_min_radius_ice()), &
-            cloud_optics%get_max_radius_ice()), &
-          cloud_props_bnd_ice)
-        TEST_(error_msg)
-
-        call MAPL_TimerOff(MAPL,"--RRTMGP_CLOUD_OPTICS",__RC__)
-
-        call MAPL_TimerOn(MAPL,"--RRTMGP_MCICA",__RC__)
-
-!!TODO: need to resolve diff between prob of max vs ran and correlation coeff in both paper and code
-
-        ! exponential inter-layer correlations
-        ! [alpha|rcorr](k) is correlation between layers k and k+1
-        ! dzmid(k) is separation between midpoints of layers k and k+1
-        if (gen_mro) then
-          do ilay = 1,LM-1
-            ! cloud fraction correlation
-            alpha(:,ilay) = exp(-abs(dzmid(colS:colE,ilay))/real(adl(colS:colE),kind=wp))
-          enddo
-          if (cond_inhomo) then
-            do ilay = 1,LM-1
-              ! condensate correlation
-              rcorr(:,ilay) = exp(-abs(dzmid(colS:colE,ilay))/real(rdl(colS:colE),kind=wp))
-            enddo
-          endif
-        endif
-
-        ! generate McICA random numbers for block
-        ! Perhaps later this can be parallelized?
-        do isub = 1, ncols_block
-          ! local 1d column index
-          icol = colS + isub - 1
-          ! initialize the Philox PRNG
-          ! set word1 of key based on GLOBAL location
-          ! 32-bits can hold all forseeable resolutions
-          seeds(1) = nint(Jg1D(icol)) * IM_World + nint(Ig1D(icol))
-#ifdef HAVE_MKL
-          ! instantiate a random number stream for the column
-          call rng%init(VSL_BRNG_PHILOX4X32X10,seeds)
-#else
-          call rng%init(seeds)
-#endif
-          ! draw the random numbers for the column
-          urand(:,:,isub) = reshape(rng%get_random(ngpt*LM),(/ngpt,LM/))
-          if (gen_mro) then
-            urand_aux(:,:,isub) = reshape(rng%get_random(ngpt*LM),(/ngpt,LM/))
-            if (cond_inhomo) then
-              urand_cond    (:,:,isub) = reshape(rng%get_random(ngpt*LM),(/ngpt,LM/))
-              urand_cond_aux(:,:,isub) = reshape(rng%get_random(ngpt*LM),(/ngpt,LM/))
-            endif
-          end if
-          ! free the rng
-          call rng%end()
-        end do
-
-        ! cloud sampling to gpoints
-        select case (cloud_overlap_type)
-          case ("MAX_RAN_OVERLAP")
-            error_msg = sampled_mask_max_ran( &
-              urand, real(CL(colS:colE,:),kind=wp), cld_mask)
-            TEST_(error_msg)
-          case ("EXP_RAN_OVERLAP")
-            ! corr_coeff(ncols_block,LM-1) is an inter-layer correlation coefficient
-            ! to be provided ... it is not the same as alpha, which is a probability
-!           error_msg = sampled_mask_exp_ran( &
-!             urand(:,:,1:ncols_block), real(CL(colS:colE,:),kind=wp), corr_coeff, cld_mask)
-!           TEST_(error_msg)
-            TEST_('EXP_RAN_OVERLAP not implemented yet')
-          case ("GEN_MAX_RAN_OVERLAP")
-            ! a scheme like Oreopoulos et al. 2012 (doi:10.5194/acp-12-9097-2012) in which both
-            ! cloud presence and cloud condensate are separately generalized maximum-random:
-            error_msg = sampled_urand_gen_max_ran(alpha, &
-              urand,urand_aux)
-            TEST_(error_msg)
-            if (cond_inhomo) then
-              error_msg = sampled_urand_gen_max_ran(rcorr, &
-                urand_cond,urand_cond_aux)
-              TEST_(error_msg)
-            end if
-            do isub = 1,ncols_block
-              icol = colS + isub - 1
-              do ilay = 1,LM
-                cld_frac = CL(icol,ilay)
-
-                ! if grid-box clear, no subgrid variability
-                if (cld_frac <= 0.) then
-                  cld_mask(isub,ilay,:) = .false.
-                else
-                  ! subgrid-scale cloud mask
-                  cld_mask(isub,ilay,:) = urand(:,ilay,isub) < cld_frac
-
-                  ! subgrid-scale condensate
-                  if (cond_inhomo) then
-                    ! level of condensate inhomogeneity based on cloud fraction.
-                    if (cld_frac > 0.99) then
-                      sigma_qcw = 0.5
-                    elseif (cld_frac > 0.9) then
-                      sigma_qcw = 0.71
-                    else
-                      sigma_qcw = 1.0
-                    endif
-                    do igpt = 1,ngpt
-                      if (cld_mask(isub,ilay,igpt)) zcw(isub,ilay,igpt) = &
-                        zcw_lookup(real(urand_cond(igpt,ilay,isub)),sigma_qcw)
-                    end do
-                  end if
-                end if
-
-              end do
-            end do
-
-          case default
-            TEST_('RRTMGP_SW: unknown cloud overlap')
-        end select
-
-        ! draw McICA optical property samples (band->gpt)
-        TEST_(draw_samples(cld_mask, cloud_props_bnd_liq, cloud_props_gpt_liq))
-        TEST_(draw_samples(cld_mask, cloud_props_bnd_ice, cloud_props_gpt_ice))
-
-        ! Scaling to sub-gridscale water paths:
-        ! since tau for each phase is linear in the phase's water path
-        ! and since the scaling zcw applies equally to both phases, the
-        ! total g-point optical thickness tau will scale with zcw.
-        if (gen_mro) then
-          if (cond_inhomo) &
-            where (cld_mask) cloud_props_gpt_liq%tau = cloud_props_gpt_liq%tau * zcw
-            where (cld_mask) cloud_props_gpt_ice%tau = cloud_props_gpt_ice%tau * zcw
-        end if
-
-        call MAPL_TimerOff(MAPL,"--RRTMGP_MCICA",__RC__)
+        call compute_cloud_optics_mcica( &
+          colS, colE, ncols_block, LM, ngpt, &
+          gen_mro, cond_inhomo, cloud_overlap_type, cwp_fac, IM_World, &
+          seeds(2), &
+          QQ3, RR3, dp_wp, dummy_wp, CL, dzmid, adl, rdl, Ig1D, Jg1D, &
+          cloud_optics, &
+          cloud_props_bnd_liq, cloud_props_bnd_ice, &
+          cloud_props_gpt_liq, cloud_props_gpt_ice, &
+          cld_mask, &
+          MAPL, __RC__)
 
         ! REFRESH super-layer diagnostics (before delta-scaling TAUs).
         ! ** Calculated from subcolumn ensemble, so stochastic **
@@ -6104,25 +5950,12 @@ contains
         call MAPL_TimerOff(MAPL,"--RRTMGP_RT",__RC__)
 
         ! deallocate per-block arrays
-        deallocate(urand,         __STAT__)
-        if (gen_mro) then
-          deallocate(urand_aux,   __STAT__)
-          if (cond_inhomo) then
-            deallocate(urand_cond,     __STAT__)
-            deallocate(urand_cond_aux, __STAT__)
-          end if
-        end if
+        ! Note: urand*, alpha, rcorr, zcw are now local to compute_cloud_optics_mcica.
+        ! cld_mask is intent(out) from that subroutine; deallocate it here after use.
         deallocate(toa_flux,      __STAT__)
         deallocate(cld_mask,      __STAT__)
         deallocate(forwliq,       __STAT__)
         deallocate(forwice,       __STAT__)
-        if (gen_mro) then
-          deallocate(alpha,       __STAT__)
-          if (cond_inhomo) then
-            deallocate(rcorr,     __STAT__)
-            deallocate(zcw,       __STAT__)
-          endif
-        endif
         if (include_aerosols) &
           deallocate(ClearCounts, __STAT__)
 
@@ -6211,20 +6044,18 @@ contains
 
       ! clean up
       deallocate(band_lims_gpt,__STAT__)
-      deallocate(tsi,mu0,sfc_alb_dir,sfc_alb_dif,toa_flux,__STAT__)
+      deallocate(tsi,mu0,sfc_alb_dir,sfc_alb_dif,__STAT__)
       deallocate(dummy_wp,p_lay,t_lay,p_lev,dp_wp,dzmid,__STAT__)
       deallocate(flux_up_clrsky,flux_net_clrsky,__STAT__)
       deallocate(flux_up_allsky,flux_net_allsky,__STAT__)
       deallocate(bnd_flux_dn_allsky,bnd_flux_net_allsky,bnd_flux_dir_allsky,__STAT__)
-      deallocate(seeds,urand,cld_mask,__STAT__)
-      deallocate(forwliq,forwice,__STAT__)
+      deallocate(seeds,__STAT__)
       if (gen_mro) then
-        deallocate(adl,alpha,urand_aux,__STAT__)
+        deallocate(adl,__STAT__)
         if (cond_inhomo) then
-          deallocate(rdl,rcorr,urand_cond,urand_cond_aux,zcw,__STAT__)
+          deallocate(rdl,__STAT__)
         endif
       end if
-      if (include_aerosols) deallocate(ClearCounts,__STAT__)
       call cloud_optics%finalize()
       call cloud_props_gpt_liq%finalize()
       call cloud_props_gpt_ice%finalize()
@@ -6922,6 +6753,245 @@ contains
       RETURN_(ESMF_SUCCESS)
 
     end subroutine compute_aer_optics
+#undef TEST_
+
+    ! ---------------------------------------------------------------------------
+    ! Compute cloud optical properties and McICA sampling for one block.
+    ! All per-block temporaries (alpha, rcorr, zcw, urand*, cld_mask, rng,
+    ! seeds) are local -- thread-private in future !$OMP PARALLEL DO use.
+    ! ---------------------------------------------------------------------------
+#define TEST_(A) error_msg = A; if (trim(error_msg)/="") then; _FAIL("RRTMGP Error: "//trim(error_msg)); endif
+    subroutine compute_cloud_optics_mcica( &
+        colS, colE, ncols_block, LM, ngpt, &
+        gen_mro, cond_inhomo, cloud_overlap_type, cwp_fac, IM_World, &
+        seeds_time_key, &
+        QQ3, RR3, dp_wp, dummy_wp, CL, dzmid, adl, rdl, Ig1D, Jg1D, &
+        cloud_optics, &
+        cloud_props_bnd_liq, cloud_props_bnd_ice, &
+        cloud_props_gpt_liq, cloud_props_gpt_ice, &
+        cld_mask, &
+        MAPL, RC)
+
+      use mo_cloud_sampling,          only: draw_samples, &
+                                            sampled_mask_max_ran, &
+                                            sampled_urand_gen_max_ran
+      use mo_cloud_optics_rrtmgp,     only: ty_cloud_optics_rrtmgp
+      use mo_optical_props,           only: ty_optical_props_arry
+      use mo_rte_kind,                only: wp
+      use cloud_condensate_inhomogeneity, only: zcw_lookup
+#ifdef HAVE_MKL
+      use MKL_VSL_TYPE
+      use mo_rng_mklvsl_plus,         only: ty_rng_mklvsl_plus
+#else
+      use mo_rng_mt19937,             only: ty_rng_mt
+#endif
+
+      integer,                        intent(in)    :: colS, colE, ncols_block, LM, ngpt
+      logical,                        intent(in)    :: gen_mro, cond_inhomo
+      character(len=*),               intent(in)    :: cloud_overlap_type
+      real(wp),                       intent(in)    :: cwp_fac
+      integer,                        intent(in)    :: IM_World
+      integer,                        intent(in)    :: seeds_time_key
+      real,             dimension(:,:,:), intent(in) :: QQ3, RR3
+      real(wp),         dimension(:,:),   intent(in) :: dp_wp, dummy_wp
+      real,             dimension(:,:),   intent(in) :: CL
+      real(wp),         dimension(:,:),   intent(in) :: dzmid
+      real,             dimension(:),     intent(in) :: adl, rdl
+      real,             dimension(:),     intent(in) :: Ig1D, Jg1D
+      type(ty_cloud_optics_rrtmgp),   intent(inout) :: cloud_optics
+      class(ty_optical_props_arry),   intent(inout) :: cloud_props_bnd_liq, cloud_props_bnd_ice
+      class(ty_optical_props_arry),   intent(inout) :: cloud_props_gpt_liq, cloud_props_gpt_ice
+      logical, allocatable,           intent(out)   :: cld_mask(:,:,:)
+      type(MAPL_MetaComp),            intent(inout) :: MAPL
+      integer, optional,              intent(out)   :: RC
+
+      ! locals -- all thread-private under future !$OMP PARALLEL DO
+      real(wp), allocatable :: alpha(:,:), rcorr(:,:)
+      real(wp), allocatable :: zcw(:,:,:)
+      real(wp), allocatable :: urand(:,:,:), urand_aux(:,:,:)
+      real(wp), allocatable :: urand_cond(:,:,:), urand_cond_aux(:,:,:)
+      integer,  allocatable :: seeds(:)
+#ifdef HAVE_MKL
+      type(ty_rng_mklvsl_plus) :: rng
+#else
+      type(ty_rng_mt) :: rng
+#endif
+      integer  :: isub, icol, ilay, igpt
+      real     :: cld_frac, sigma_qcw
+      character(len=ESMF_MAXSTR) :: error_msg
+      integer  :: STATUS
+
+      ! allocate locals sized to this block
+      allocate(urand(ngpt,LM,ncols_block))
+      allocate(cld_mask(ncols_block,LM,ngpt))
+      if (gen_mro) then
+        allocate(urand_aux(ngpt,LM,ncols_block))
+        allocate(alpha(ncols_block,LM-1))
+        if (cond_inhomo) then
+          allocate(urand_cond    (ngpt,LM,ncols_block))
+          allocate(urand_cond_aux(ngpt,LM,ncols_block))
+          allocate(rcorr(ncols_block,LM-1))
+          allocate(zcw(ncols_block,LM,ngpt))
+        end if
+      end if
+      allocate(seeds(3))    ! 2-word key plus word1 of counter
+      seeds    = 0
+      seeds(2) = seeds_time_key   ! time part of key (computed once outside block loop)
+      ! for SW start at counter=65,536
+      seeds(3) = 65536
+
+      call MAPL_TimerOn(MAPL,"--RRTMGP_CLOUD_OPTICS",__RC__)
+
+      ! Make band in-cloud optical props from cloud_optics and mean in-cloud cloud water paths.
+      ! These can be scaled later to account for sub-gridscale condensate inhomogeneity.
+      ! Do phases separately to allow for different forward scattering, etc., per earlier note.
+      ! liquid ...
+      error_msg = cloud_optics%cloud_optics( &
+        real(QQ3(colS:colE,:,2),kind=wp) * dp_wp(colS:colE,:) * cwp_fac, &  ! [g/m2]
+        dummy_wp(colS:colE,:), &
+        min( max( real(RR3(colS:colE,:,2),kind=wp), &  ! [microns]
+          cloud_optics%get_min_radius_liq()), &
+          cloud_optics%get_max_radius_liq()), &
+        dummy_wp(colS:colE,:), &
+        cloud_props_bnd_liq)
+      TEST_(error_msg)
+      ! ice ...
+      error_msg = cloud_optics%cloud_optics( &
+        dummy_wp(colS:colE,:), &
+        real(QQ3(colS:colE,:,1),kind=wp) * dp_wp(colS:colE,:) * cwp_fac, &  ! [g/m2]
+        dummy_wp(colS:colE,:), &
+        min( max( real(RR3(colS:colE,:,1),kind=wp), &  ! [microns]
+          cloud_optics%get_min_radius_ice()), &
+          cloud_optics%get_max_radius_ice()), &
+        cloud_props_bnd_ice)
+      TEST_(error_msg)
+
+      call MAPL_TimerOff(MAPL,"--RRTMGP_CLOUD_OPTICS",__RC__)
+
+      call MAPL_TimerOn(MAPL,"--RRTMGP_MCICA",__RC__)
+
+!!TODO: need to resolve diff between prob of max vs ran and correlation coeff in both paper and code
+
+      ! exponential inter-layer correlations
+      ! [alpha|rcorr](k) is correlation between layers k and k+1
+      ! dzmid(k) is separation between midpoints of layers k and k+1
+      if (gen_mro) then
+        do ilay = 1,LM-1
+          ! cloud fraction correlation
+          alpha(:,ilay) = exp(-abs(dzmid(colS:colE,ilay))/real(adl(colS:colE),kind=wp))
+        enddo
+        if (cond_inhomo) then
+          do ilay = 1,LM-1
+            ! condensate correlation
+            rcorr(:,ilay) = exp(-abs(dzmid(colS:colE,ilay))/real(rdl(colS:colE),kind=wp))
+          enddo
+        endif
+      endif
+
+      ! generate McICA random numbers for block
+      do isub = 1, ncols_block
+        ! local 1d column index
+        icol = colS + isub - 1
+        ! initialize the Philox PRNG
+        ! set word1 of key based on GLOBAL location
+        ! 32-bits can hold all forseeable resolutions
+        seeds(1) = nint(Jg1D(icol)) * IM_World + nint(Ig1D(icol))
+#ifdef HAVE_MKL
+        ! instantiate a random number stream for the column
+        call rng%init(VSL_BRNG_PHILOX4X32X10,seeds)
+#else
+        call rng%init(seeds)
+#endif
+        ! draw the random numbers for the column
+        urand(:,:,isub) = reshape(rng%get_random(ngpt*LM),(/ngpt,LM/))
+        if (gen_mro) then
+          urand_aux(:,:,isub) = reshape(rng%get_random(ngpt*LM),(/ngpt,LM/))
+          if (cond_inhomo) then
+            urand_cond    (:,:,isub) = reshape(rng%get_random(ngpt*LM),(/ngpt,LM/))
+            urand_cond_aux(:,:,isub) = reshape(rng%get_random(ngpt*LM),(/ngpt,LM/))
+          endif
+        end if
+        ! free the rng
+        call rng%end()
+      end do
+
+      ! cloud sampling to gpoints
+      select case (cloud_overlap_type)
+        case ("MAX_RAN_OVERLAP")
+          error_msg = sampled_mask_max_ran( &
+            urand, real(CL(colS:colE,:),kind=wp), cld_mask)
+          TEST_(error_msg)
+        case ("EXP_RAN_OVERLAP")
+          ! corr_coeff(ncols_block,LM-1) is an inter-layer correlation coefficient
+          ! to be provided ... it is not the same as alpha, which is a probability
+!         error_msg = sampled_mask_exp_ran( &
+!           urand, real(CL(colS:colE,:),kind=wp), corr_coeff, cld_mask)
+!         TEST_(error_msg)
+          TEST_('EXP_RAN_OVERLAP not implemented yet')
+        case ("GEN_MAX_RAN_OVERLAP")
+          ! a scheme like Oreopoulos et al. 2012 (doi:10.5194/acp-12-9097-2012) in which both
+          ! cloud presence and cloud condensate are separately generalized maximum-random:
+          error_msg = sampled_urand_gen_max_ran(alpha, urand, urand_aux)
+          TEST_(error_msg)
+          if (cond_inhomo) then
+            error_msg = sampled_urand_gen_max_ran(rcorr, urand_cond, urand_cond_aux)
+            TEST_(error_msg)
+          end if
+          do isub = 1,ncols_block
+            icol = colS + isub - 1
+            do ilay = 1,LM
+              cld_frac = CL(icol,ilay)
+
+              ! if grid-box clear, no subgrid variability
+              if (cld_frac <= 0.) then
+                cld_mask(isub,ilay,:) = .false.
+              else
+                ! subgrid-scale cloud mask
+                cld_mask(isub,ilay,:) = urand(:,ilay,isub) < cld_frac
+
+                ! subgrid-scale condensate
+                if (cond_inhomo) then
+                  ! level of condensate inhomogeneity based on cloud fraction.
+                  if (cld_frac > 0.99) then
+                    sigma_qcw = 0.5
+                  elseif (cld_frac > 0.9) then
+                    sigma_qcw = 0.71
+                  else
+                    sigma_qcw = 1.0
+                  endif
+                  do igpt = 1,ngpt
+                    if (cld_mask(isub,ilay,igpt)) zcw(isub,ilay,igpt) = &
+                      zcw_lookup(real(urand_cond(igpt,ilay,isub)),sigma_qcw)
+                  end do
+                end if
+              end if
+
+            end do
+          end do
+
+        case default
+          TEST_('RRTMGP_SW: unknown cloud overlap')
+      end select
+
+      ! draw McICA optical property samples (band->gpt)
+      TEST_(draw_samples(cld_mask, cloud_props_bnd_liq, cloud_props_gpt_liq))
+      TEST_(draw_samples(cld_mask, cloud_props_bnd_ice, cloud_props_gpt_ice))
+
+      ! Scaling to sub-gridscale water paths:
+      ! since tau for each phase is linear in the phase's water path
+      ! and since the scaling zcw applies equally to both phases, the
+      ! total g-point optical thickness tau will scale with zcw.
+      if (gen_mro) then
+        if (cond_inhomo) &
+          where (cld_mask) cloud_props_gpt_liq%tau = cloud_props_gpt_liq%tau * zcw
+          where (cld_mask) cloud_props_gpt_ice%tau = cloud_props_gpt_ice%tau * zcw
+      end if
+
+      call MAPL_TimerOff(MAPL,"--RRTMGP_MCICA",__RC__)
+
+      RETURN_(ESMF_SUCCESS)
+
+    end subroutine compute_cloud_optics_mcica
 #undef TEST_
 
 

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -5337,265 +5337,31 @@ contains
         ! REFRESH super-layer diagnostics (after delta-scaling TAUs).
         ! ** Calculated from subcolumn ensemble, so stochastic **
         ! -------------------------------------------------------
-        call MAPL_TimerOn(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
-        if (include_aerosols) then
-
-          ! in-cloud optical thicknesses in PAR super-band
-          ! (weighted across and within bands by TOA incident flux)
-          do isub = 1,ncols_block
-            icol = colS + isub - 1
-
-            ! zero denom- and numerator accumulators
-            CDSDTP(icol) = 0.; CDSNTP(icol) = 0.
-            CDSDHP(icol) = 0.; CDSNHP(icol) = 0.
-            CDSDMP(icol) = 0.; CDSNMP(icol) = 0.
-            CDSDLP(icol) = 0.; CDSNLP(icol) = 0.
-
-            CDSLDTP(icol) = 0.; CDSLNTP(icol) = 0.; CDSIDTP(icol) = 0.; CDSINTP(icol) = 0.
-            CDSLDHP(icol) = 0.; CDSLNHP(icol) = 0.; CDSIDHP(icol) = 0.; CDSINHP(icol) = 0.
-            CDSLDMP(icol) = 0.; CDSLNMP(icol) = 0.; CDSIDMP(icol) = 0.; CDSINMP(icol) = 0.
-            CDSLDLP(icol) = 0.; CDSLNLP(icol) = 0.; CDSIDLP(icol) = 0.; CDSINLP(icol) = 0.
-
-            SDSLDTP(icol) = 0.; SDSLNTP(icol) = 0.; SDSIDTP(icol) = 0.; SDSINTP(icol) = 0.
-            SDSLDHP(icol) = 0.; SDSLNHP(icol) = 0.; SDSIDHP(icol) = 0.; SDSINHP(icol) = 0.
-            SDSLDMP(icol) = 0.; SDSLNMP(icol) = 0.; SDSIDMP(icol) = 0.; SDSINMP(icol) = 0.
-            SDSLDLP(icol) = 0.; SDSLNLP(icol) = 0.; SDSIDLP(icol) = 0.; SDSINLP(icol) = 0.
-
-            ADSLDTP(icol) = 0.; ADSLNTP(icol) = 0.; ADSIDTP(icol) = 0.; ADSINTP(icol) = 0.
-            ADSLDHP(icol) = 0.; ADSLNHP(icol) = 0.; ADSIDHP(icol) = 0.; ADSINHP(icol) = 0.
-            ADSLDMP(icol) = 0.; ADSLNMP(icol) = 0.; ADSIDMP(icol) = 0.; ADSINMP(icol) = 0.
-            ADSLDLP(icol) = 0.; ADSLNLP(icol) = 0.; ADSIDLP(icol) = 0.; ADSINLP(icol) = 0.
-
-            FORLDTP(icol) = 0.; FORLNTP(icol) = 0.; FORIDTP(icol) = 0.; FORINTP(icol) = 0.
-            FORLDHP(icol) = 0.; FORLNHP(icol) = 0.; FORIDHP(icol) = 0.; FORINHP(icol) = 0.
-            FORLDMP(icol) = 0.; FORLNMP(icol) = 0.; FORIDMP(icol) = 0.; FORINMP(icol) = 0.
-            FORLDLP(icol) = 0.; FORLNLP(icol) = 0.; FORIDLP(icol) = 0.; FORINLP(icol) = 0.
-
-            ! can only be non-zero for potentially cloudy columns
-            if (any(CL(icol,:) > 0.)) then
-
-              ! accumulate over gpts/subcolumns
-              do ib = 1, nbnd
-                do igpt = band_lims_gpt(1,ib), band_lims_gpt(2,ib)
-
-                  ! band weights for photosynthetically active radiation (PAR)
-                  ! Bands 11-12 (0.345-0.625 um) plus half transition band 10 (0.625-0.778 um)
-                  if (ib >= 11 .and. ib <= 12) then
-                    wgt = 1.0
-                  else if (ib == 10) then
-                    wgt = 0.5
-                  else
-                    ! no contribution to PAR
-                    cycle
-                  end if
-
-                  ! TOA flux weighting
-                  ! (note: neither the adjustment of toa_flux to our tsi
-                  ! or for zenith angle are needed yet since this weighting
-                  ! is over gpoint and is normalized for EACH icol)
-                  wgt = wgt * toa_flux(isub,igpt)
-
-                  ! low pressure layer
-                  sltaulp = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt))
-                  sitaulp = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt))
-                  staulp = sltaulp + sitaulp
-                  if (staulp > 0.) then
-                    CDSNLP(icol) = CDSNLP(icol) + wgt * staulp
-                    CDSDLP(icol) = CDSDLP(icol) + wgt
-                  end if
-                  sltaussalp = 0.; sltaussaglp = 0.; sltaussaflp = 0.
-                  if (sltaulp > 0.) then
-                    select type(cloud_props_gpt_liq)
-                    class is (ty_optical_props_2str)
-                      sltaussalp = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt) * &
-                                       cloud_props_gpt_liq%ssa(isub,LCLDLM:LM,igpt))
-                      sltaussaglp = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt) * &
-                                        cloud_props_gpt_liq%ssa(isub,LCLDLM:LM,igpt) * &
-                                        cloud_props_gpt_liq%g  (isub,LCLDLM:LM,igpt))
-                      sltaussaflp = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt) * &
-                                        cloud_props_gpt_liq%ssa(isub,LCLDLM:LM,igpt) * &
-                                                        forwliq(isub,LCLDLM:LM,igpt))
-                    end select
-                    CDSLDLP(icol) = CDSLDLP(icol) + wgt
-                    CDSLNLP(icol) = CDSLNLP(icol) + wgt * sltaulp
-                    SDSLDLP(icol) = SDSLDLP(icol) + wgt * sltaulp
-                    SDSLNLP(icol) = SDSLNLP(icol) + wgt * sltaussalp
-                    ADSLDLP(icol) = ADSLDLP(icol) + wgt * sltaussalp
-                    ADSLNLP(icol) = ADSLNLP(icol) + wgt * sltaussaglp
-                    FORLDLP(icol) = FORLDLP(icol) + wgt * sltaussalp
-                    FORLNLP(icol) = FORLNLP(icol) + wgt * sltaussaflp
-                  end if
-                  sitaussalp = 0.; sitaussaglp = 0.; sitaussaflp = 0.
-                  if (sitaulp > 0.) then
-                    select type(cloud_props_gpt_ice)
-                    class is (ty_optical_props_2str)
-                      sitaussalp = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt) * &
-                                       cloud_props_gpt_ice%ssa(isub,LCLDLM:LM,igpt))
-                      sitaussaglp = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt) * &
-                                        cloud_props_gpt_ice%ssa(isub,LCLDLM:LM,igpt) * &
-                                        cloud_props_gpt_ice%g  (isub,LCLDLM:LM,igpt))
-                      sitaussaflp = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt) * &
-                                        cloud_props_gpt_ice%ssa(isub,LCLDLM:LM,igpt) * &
-                                                        forwice(isub,LCLDLM:LM,igpt))
-                    end select
-                    CDSIDLP(icol) = CDSIDLP(icol) + wgt
-                    CDSINLP(icol) = CDSINLP(icol) + wgt * sitaulp
-                    SDSIDLP(icol) = SDSIDLP(icol) + wgt * sitaulp
-                    SDSINLP(icol) = SDSINLP(icol) + wgt * sitaussalp
-                    ADSIDLP(icol) = ADSIDLP(icol) + wgt * sitaussalp
-                    ADSINLP(icol) = ADSINLP(icol) + wgt * sitaussaglp
-                    FORIDLP(icol) = FORIDLP(icol) + wgt * sitaussalp
-                    FORINLP(icol) = FORINLP(icol) + wgt * sitaussaflp
-                  end if
-
-                  ! mid pressure layer
-                  sltaump = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt))
-                  sitaump = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt))
-                  staump = sltaump + sitaump
-                  if (staump > 0.) then
-                    CDSNMP(icol) = CDSNMP(icol) + wgt * staump
-                    CDSDMP(icol) = CDSDMP(icol) + wgt
-                  end if
-                  sltaussamp = 0.; sltaussagmp = 0.; sltaussafmp = 0.
-                  if (sltaump > 0.) then
-                    select type(cloud_props_gpt_liq)
-                    class is (ty_optical_props_2str)
-                      sltaussamp = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                       cloud_props_gpt_liq%ssa(isub,LCLDMH:LCLDLM-1,igpt))
-                      sltaussagmp = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                        cloud_props_gpt_liq%ssa(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                        cloud_props_gpt_liq%g  (isub,LCLDMH:LCLDLM-1,igpt))
-                      sltaussafmp = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                        cloud_props_gpt_liq%ssa(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                                        forwliq(isub,LCLDMH:LCLDLM-1,igpt))
-                    end select
-                    CDSLDMP(icol) = CDSLDMP(icol) + wgt
-                    CDSLNMP(icol) = CDSLNMP(icol) + wgt * sltaump
-                    SDSLDMP(icol) = SDSLDMP(icol) + wgt * sltaump
-                    SDSLNMP(icol) = SDSLNMP(icol) + wgt * sltaussamp
-                    ADSLDMP(icol) = ADSLDMP(icol) + wgt * sltaussamp
-                    ADSLNMP(icol) = ADSLNMP(icol) + wgt * sltaussagmp
-                    FORLDMP(icol) = FORLDMP(icol) + wgt * sltaussamp
-                    FORLNMP(icol) = FORLNMP(icol) + wgt * sltaussafmp
-                  end if
-                  sitaussamp = 0.; sitaussagmp = 0.; sitaussafmp = 0.
-                  if (sitaump > 0.) then
-                    select type(cloud_props_gpt_ice)
-                    class is (ty_optical_props_2str)
-                      sitaussamp = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                       cloud_props_gpt_ice%ssa(isub,LCLDMH:LCLDLM-1,igpt))
-                      sitaussagmp = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                        cloud_props_gpt_ice%ssa(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                        cloud_props_gpt_ice%g  (isub,LCLDMH:LCLDLM-1,igpt))
-                      sitaussafmp = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                        cloud_props_gpt_ice%ssa(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                                        forwice(isub,LCLDMH:LCLDLM-1,igpt))
-                    end select
-                    CDSIDMP(icol) = CDSIDMP(icol) + wgt
-                    CDSINMP(icol) = CDSINMP(icol) + wgt * sitaump
-                    SDSIDMP(icol) = SDSIDMP(icol) + wgt * sitaump
-                    SDSINMP(icol) = SDSINMP(icol) + wgt * sitaussamp
-                    ADSIDMP(icol) = ADSIDMP(icol) + wgt * sitaussamp
-                    ADSINMP(icol) = ADSINMP(icol) + wgt * sitaussagmp
-                    FORIDMP(icol) = FORIDMP(icol) + wgt * sitaussamp
-                    FORINMP(icol) = FORINMP(icol) + wgt * sitaussafmp
-                  end if
-
-                  ! high pressure layer
-                  sltauhp = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt))
-                  sitauhp = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt))
-                  stauhp = sltauhp + sitauhp
-                  if (stauhp > 0.) then
-                    CDSNHP(icol) = CDSNHP(icol) + wgt * stauhp
-                    CDSDHP(icol) = CDSDHP(icol) + wgt
-                  end if
-                  sltaussahp = 0.; sltaussaghp = 0.; sltaussafhp = 0.
-                  if (sltauhp > 0.) then
-                    select type(cloud_props_gpt_liq)
-                    class is (ty_optical_props_2str)
-                      sltaussahp = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt) * &
-                                       cloud_props_gpt_liq%ssa(isub,1:LCLDMH-1,igpt))
-                      sltaussaghp = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt) * &
-                                        cloud_props_gpt_liq%ssa(isub,1:LCLDMH-1,igpt) * &
-                                        cloud_props_gpt_liq%g  (isub,1:LCLDMH-1,igpt))
-                      sltaussafhp = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt) * &
-                                        cloud_props_gpt_liq%ssa(isub,1:LCLDMH-1,igpt) * &
-                                                        forwliq(isub,1:LCLDMH-1,igpt))
-                    end select
-                    CDSLDHP(icol) = CDSLDHP(icol) + wgt
-                    CDSLNHP(icol) = CDSLNHP(icol) + wgt * sltauhp
-                    SDSLDHP(icol) = SDSLDHP(icol) + wgt * sltauhp
-                    SDSLNHP(icol) = SDSLNHP(icol) + wgt * sltaussahp
-                    ADSLDHP(icol) = ADSLDHP(icol) + wgt * sltaussahp
-                    ADSLNHP(icol) = ADSLNHP(icol) + wgt * sltaussaghp
-                    FORLDHP(icol) = FORLDHP(icol) + wgt * sltaussahp
-                    FORLNHP(icol) = FORLNHP(icol) + wgt * sltaussafhp
-                  end if
-                  sitaussahp = 0.; sitaussaghp = 0.; sitaussafhp = 0.
-                  if (sitauhp > 0.) then
-                    select type(cloud_props_gpt_ice)
-                    class is (ty_optical_props_2str)
-                      sitaussahp = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt) * &
-                                       cloud_props_gpt_ice%ssa(isub,1:LCLDMH-1,igpt))
-                      sitaussaghp = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt) * &
-                                        cloud_props_gpt_ice%ssa(isub,1:LCLDMH-1,igpt) * &
-                                        cloud_props_gpt_ice%g  (isub,1:LCLDMH-1,igpt))
-                      sitaussafhp = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt) * &
-                                        cloud_props_gpt_ice%ssa(isub,1:LCLDMH-1,igpt) * &
-                                                        forwice(isub,1:LCLDMH-1,igpt))
-                    end select
-                    CDSIDHP(icol) = CDSIDHP(icol) + wgt
-                    CDSINHP(icol) = CDSINHP(icol) + wgt * sitauhp
-                    SDSIDHP(icol) = SDSIDHP(icol) + wgt * sitauhp
-                    SDSINHP(icol) = SDSINHP(icol) + wgt * sitaussahp
-                    ADSIDHP(icol) = ADSIDHP(icol) + wgt * sitaussahp
-                    ADSINHP(icol) = ADSINHP(icol) + wgt * sitaussaghp
-                    FORIDHP(icol) = FORIDHP(icol) + wgt * sitaussahp
-                    FORINHP(icol) = FORINHP(icol) + wgt * sitaussafhp
-                  end if
-
-                  ! whole subcolumn
-                  sltautp = sltaulp + sltaump + sltauhp
-                  sitautp = sitaulp + sitaump + sitauhp
-                  stautp = staulp + staump + stauhp
-                  if (stautp > 0.) then
-                    CDSNTP(icol) = CDSNTP(icol) + wgt * stautp
-                    CDSDTP(icol) = CDSDTP(icol) + wgt
-                  end if
-                  sltaussatp = sltaussalp + sltaussamp + sltaussahp
-                  sltaussagtp = sltaussaglp + sltaussagmp + sltaussaghp
-                  sltaussaftp = sltaussaflp + sltaussafmp + sltaussafhp
-                  if (sltautp > 0.) then
-                    CDSLDTP(icol) = CDSLDTP(icol) + wgt
-                    CDSLNTP(icol) = CDSLNTP(icol) + wgt * sltautp
-                    SDSLDTP(icol) = SDSLDTP(icol) + wgt * sltautp
-                    SDSLNTP(icol) = SDSLNTP(icol) + wgt * sltaussatp
-                    ADSLDTP(icol) = ADSLDTP(icol) + wgt * sltaussatp
-                    ADSLNTP(icol) = ADSLNTP(icol) + wgt * sltaussagtp
-                    FORLDTP(icol) = FORLDTP(icol) + wgt * sltaussatp
-                    FORLNTP(icol) = FORLNTP(icol) + wgt * sltaussaftp
-                  end if
-                  sitaussatp = sitaussalp + sitaussamp + sitaussahp
-                  sitaussagtp = sitaussaglp + sitaussagmp + sitaussaghp
-                  sitaussaftp = sitaussaflp + sitaussafmp + sitaussafhp
-                  if (sitautp > 0.) then
-                    CDSIDTP(icol) = CDSIDTP(icol) + wgt
-                    CDSINTP(icol) = CDSINTP(icol) + wgt * sitautp
-                    SDSIDTP(icol) = SDSIDTP(icol) + wgt * sitautp
-                    SDSINTP(icol) = SDSINTP(icol) + wgt * sitaussatp
-                    ADSIDTP(icol) = ADSIDTP(icol) + wgt * sitaussatp
-                    ADSINTP(icol) = ADSINTP(icol) + wgt * sitaussagtp
-                    FORIDTP(icol) = FORIDTP(icol) + wgt * sitaussatp
-                    FORINTP(icol) = FORINTP(icol) + wgt * sitaussaftp
-                  end if
-
-                end do ! igpt
-              end do ! ib
-
-            end if  ! potentially cloudy column
-          end do  ! isub
-        end if  ! include_aerosols
-        call MAPL_TimerOff(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
+        call compute_sprlyr_diags_postdelta( &
+          colS, ncols_block, LM, ngpt, nbnd, LCLDLM, LCLDMH, &
+          include_aerosols, &
+          CL, toa_flux, band_lims_gpt, &
+          forwliq, forwice, &
+          cloud_props_gpt_liq, cloud_props_gpt_ice, &
+          CDSDTP, CDSDHP, CDSDMP, CDSDLP, &
+          CDSNTP, CDSNHP, CDSNMP, CDSNLP, &
+          CDSLDTP, CDSLDHP, CDSLDMP, CDSLDLP, &
+          CDSLNTP, CDSLNHP, CDSLNMP, CDSLNLP, &
+          CDSIDTP, CDSIDHP, CDSIDMP, CDSIDLP, &
+          CDSINTP, CDSINHP, CDSINMP, CDSINLP, &
+          SDSLDTP, SDSLDHP, SDSLDMP, SDSLDLP, &
+          SDSLNTP, SDSLNHP, SDSLNMP, SDSLNLP, &
+          SDSIDTP, SDSIDHP, SDSIDMP, SDSIDLP, &
+          SDSINTP, SDSINHP, SDSINMP, SDSINLP, &
+          ADSLDTP, ADSLDHP, ADSLDMP, ADSLDLP, &
+          ADSLNTP, ADSLNHP, ADSLNMP, ADSLNLP, &
+          ADSIDTP, ADSIDHP, ADSIDMP, ADSIDLP, &
+          ADSINTP, ADSINHP, ADSINMP, ADSINLP, &
+          FORLDTP, FORLDHP, FORLDMP, FORLDLP, &
+          FORLNTP, FORLNHP, FORLNMP, FORLNLP, &
+          FORIDTP, FORIDHP, FORIDMP, FORIDLP, &
+          FORINTP, FORINHP, FORINMP, FORINLP, &
+          MAPL, __RC__)
 #endif
 
         call MAPL_TimerOn(MAPL,"--RRTMGP_RT",__RC__)
@@ -7157,6 +6923,349 @@ contains
       RETURN_(ESMF_SUCCESS)
 
     end subroutine compute_delta_scale
+#undef TEST_
+
+    ! ---------------------------------------------------------------------------
+    ! Super-layer cloud optical depth diagnostics AFTER delta-scaling.
+    ! Only compiled/called under #ifdef SOLAR_RADVAL.
+    ! forwliq and forwice (from compute_delta_scale) are intent(in) here.
+    ! All scalar temporaries are local (thread-private under future OMP).
+    ! ---------------------------------------------------------------------------
+#define TEST_(A) error_msg = A; if (trim(error_msg)/="") then; _FAIL("RRTMGP Error: "//trim(error_msg)); endif
+    subroutine compute_sprlyr_diags_postdelta( &
+        colS, ncols_block, LM, ngpt, nbnd, LCLDLM, LCLDMH, &
+        include_aerosols, &
+        CL, toa_flux, band_lims_gpt, &
+        forwliq, forwice, &
+        cloud_props_gpt_liq, cloud_props_gpt_ice, &
+        CDSDTP, CDSDHP, CDSDMP, CDSDLP, &
+        CDSNTP, CDSNHP, CDSNMP, CDSNLP, &
+        CDSLDTP, CDSLDHP, CDSLDMP, CDSLDLP, &
+        CDSLNTP, CDSLNHP, CDSLNMP, CDSLNLP, &
+        CDSIDTP, CDSIDHP, CDSIDMP, CDSIDLP, &
+        CDSINTP, CDSINHP, CDSINMP, CDSINLP, &
+        SDSLDTP, SDSLDHP, SDSLDMP, SDSLDLP, &
+        SDSLNTP, SDSLNHP, SDSLNMP, SDSLNLP, &
+        SDSIDTP, SDSIDHP, SDSIDMP, SDSIDLP, &
+        SDSINTP, SDSINHP, SDSINMP, SDSINLP, &
+        ADSLDTP, ADSLDHP, ADSLDMP, ADSLDLP, &
+        ADSLNTP, ADSLNHP, ADSLNMP, ADSLNLP, &
+        ADSIDTP, ADSIDHP, ADSIDMP, ADSIDLP, &
+        ADSINTP, ADSINHP, ADSINMP, ADSINLP, &
+        FORLDTP, FORLDHP, FORLDMP, FORLDLP, &
+        FORLNTP, FORLNHP, FORLNMP, FORLNLP, &
+        FORIDTP, FORIDHP, FORIDMP, FORIDLP, &
+        FORINTP, FORINHP, FORINMP, FORINLP, &
+        MAPL, RC)
+
+      use mo_optical_props, only: ty_optical_props_arry, ty_optical_props_2str
+      use mo_rte_kind,      only: wp
+
+      integer,                      intent(in)    :: colS, ncols_block, LM, ngpt, nbnd
+      integer,                      intent(in)    :: LCLDLM, LCLDMH
+      logical,                      intent(in)    :: include_aerosols
+      real,             intent(in)  :: CL(:,:)
+      real(wp),         intent(in)  :: toa_flux(:,:)
+      integer,          intent(in)  :: band_lims_gpt(:,:)
+      real(wp),         intent(in)  :: forwliq(:,:,:), forwice(:,:,:)
+      class(ty_optical_props_arry), intent(in) :: cloud_props_gpt_liq, cloud_props_gpt_ice
+      real,             intent(inout) :: CDSDTP(:), CDSDHP(:), CDSDMP(:), CDSDLP(:)
+      real,             intent(inout) :: CDSNTP(:), CDSNHP(:), CDSNMP(:), CDSNLP(:)
+      real,             intent(inout) :: CDSLDTP(:), CDSLDHP(:), CDSLDMP(:), CDSLDLP(:)
+      real,             intent(inout) :: CDSLNTP(:), CDSLNHP(:), CDSLNMP(:), CDSLNLP(:)
+      real,             intent(inout) :: CDSIDTP(:), CDSIDHP(:), CDSIDMP(:), CDSIDLP(:)
+      real,             intent(inout) :: CDSINTP(:), CDSINHP(:), CDSINMP(:), CDSINLP(:)
+      real,             intent(inout) :: SDSLDTP(:), SDSLDHP(:), SDSLDMP(:), SDSLDLP(:)
+      real,             intent(inout) :: SDSLNTP(:), SDSLNHP(:), SDSLNMP(:), SDSLNLP(:)
+      real,             intent(inout) :: SDSIDTP(:), SDSIDHP(:), SDSIDMP(:), SDSIDLP(:)
+      real,             intent(inout) :: SDSINTP(:), SDSINHP(:), SDSINMP(:), SDSINLP(:)
+      real,             intent(inout) :: ADSLDTP(:), ADSLDHP(:), ADSLDMP(:), ADSLDLP(:)
+      real,             intent(inout) :: ADSLNTP(:), ADSLNHP(:), ADSLNMP(:), ADSLNLP(:)
+      real,             intent(inout) :: ADSIDTP(:), ADSIDHP(:), ADSIDMP(:), ADSIDLP(:)
+      real,             intent(inout) :: ADSINTP(:), ADSINHP(:), ADSINMP(:), ADSINLP(:)
+      real,             intent(inout) :: FORLDTP(:), FORLDHP(:), FORLDMP(:), FORLDLP(:)
+      real,             intent(inout) :: FORLNTP(:), FORLNHP(:), FORLNMP(:), FORLNLP(:)
+      real,             intent(inout) :: FORIDTP(:), FORIDHP(:), FORIDMP(:), FORIDLP(:)
+      real,             intent(inout) :: FORINTP(:), FORINHP(:), FORINMP(:), FORINLP(:)
+      type(MAPL_MetaComp),          intent(inout) :: MAPL
+      integer, optional,            intent(out)   :: RC
+
+      ! locals -- all thread-private under future !$OMP PARALLEL DO
+      integer  :: isub, icol, ib, igpt
+      real     :: wgt
+      real     :: stautp, stauhp, staump, staulp
+      real     :: sltautp, sltauhp, sltaump, sltaulp
+      real     :: sitautp, sitauhp, sitaump, sitaulp
+      real     :: sltaussatp, sltaussahp, sltaussamp, sltaussalp
+      real     :: sitaussatp, sitaussahp, sitaussamp, sitaussalp
+      real     :: sltaussagtp, sltaussaghp, sltaussagmp, sltaussaglp
+      real     :: sitaussagtp, sitaussaghp, sitaussagmp, sitaussaglp
+      real     :: sltaussaftp, sltaussafhp, sltaussafmp, sltaussaflp
+      real     :: sitaussaftp, sitaussafhp, sitaussafmp, sitaussaflp
+      character(len=ESMF_MAXSTR) :: error_msg
+      integer  :: STATUS
+
+      call MAPL_TimerOn(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
+
+      if (include_aerosols) then
+
+        ! in-cloud optical thicknesses in PAR super-band
+        ! (weighted across and within bands by TOA incident flux)
+        do isub = 1,ncols_block
+          icol = colS + isub - 1
+
+          ! zero denom- and numerator accumulators
+          CDSDTP(icol) = 0.; CDSNTP(icol) = 0.
+          CDSDHP(icol) = 0.; CDSNHP(icol) = 0.
+          CDSDMP(icol) = 0.; CDSNMP(icol) = 0.
+          CDSDLP(icol) = 0.; CDSNLP(icol) = 0.
+
+          CDSLDTP(icol) = 0.; CDSLNTP(icol) = 0.; CDSIDTP(icol) = 0.; CDSINTP(icol) = 0.
+          CDSLDHP(icol) = 0.; CDSLNHP(icol) = 0.; CDSIDHP(icol) = 0.; CDSINHP(icol) = 0.
+          CDSLDMP(icol) = 0.; CDSLNMP(icol) = 0.; CDSIDMP(icol) = 0.; CDSINMP(icol) = 0.
+          CDSLDLP(icol) = 0.; CDSLNLP(icol) = 0.; CDSIDLP(icol) = 0.; CDSINLP(icol) = 0.
+
+          SDSLDTP(icol) = 0.; SDSLNTP(icol) = 0.; SDSIDTP(icol) = 0.; SDSINTP(icol) = 0.
+          SDSLDHP(icol) = 0.; SDSLNHP(icol) = 0.; SDSIDHP(icol) = 0.; SDSINHP(icol) = 0.
+          SDSLDMP(icol) = 0.; SDSLNMP(icol) = 0.; SDSIDMP(icol) = 0.; SDSINMP(icol) = 0.
+          SDSLDLP(icol) = 0.; SDSLNLP(icol) = 0.; SDSIDLP(icol) = 0.; SDSINLP(icol) = 0.
+
+          ADSLDTP(icol) = 0.; ADSLNTP(icol) = 0.; ADSIDTP(icol) = 0.; ADSINTP(icol) = 0.
+          ADSLDHP(icol) = 0.; ADSLNHP(icol) = 0.; ADSIDHP(icol) = 0.; ADSINHP(icol) = 0.
+          ADSLDMP(icol) = 0.; ADSLNMP(icol) = 0.; ADSIDMP(icol) = 0.; ADSINMP(icol) = 0.
+          ADSLDLP(icol) = 0.; ADSLNLP(icol) = 0.; ADSIDLP(icol) = 0.; ADSINLP(icol) = 0.
+
+          FORLDTP(icol) = 0.; FORLNTP(icol) = 0.; FORIDTP(icol) = 0.; FORINTP(icol) = 0.
+          FORLDHP(icol) = 0.; FORLNHP(icol) = 0.; FORIDHP(icol) = 0.; FORINHP(icol) = 0.
+          FORLDMP(icol) = 0.; FORLNMP(icol) = 0.; FORIDMP(icol) = 0.; FORINMP(icol) = 0.
+          FORLDLP(icol) = 0.; FORLNLP(icol) = 0.; FORIDLP(icol) = 0.; FORINLP(icol) = 0.
+
+          ! can only be non-zero for potentially cloudy columns
+          if (any(CL(icol,:) > 0.)) then
+
+            ! accumulate over gpts/subcolumns
+            do ib = 1, nbnd
+              do igpt = band_lims_gpt(1,ib), band_lims_gpt(2,ib)
+
+                ! band weights for photosynthetically active radiation (PAR)
+                ! Bands 11-12 (0.345-0.625 um) plus half transition band 10 (0.625-0.778 um)
+                if (ib >= 11 .and. ib <= 12) then
+                  wgt = 1.0
+                else if (ib == 10) then
+                  wgt = 0.5
+                else
+                  ! no contribution to PAR
+                  cycle
+                end if
+
+                wgt = wgt * toa_flux(isub,igpt)
+
+                ! low pressure layer
+                sltaulp = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt))
+                sitaulp = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt))
+                staulp = sltaulp + sitaulp
+                if (staulp > 0.) then
+                  CDSNLP(icol) = CDSNLP(icol) + wgt * staulp
+                  CDSDLP(icol) = CDSDLP(icol) + wgt
+                end if
+                sltaussalp = 0.; sltaussaglp = 0.; sltaussaflp = 0.
+                if (sltaulp > 0.) then
+                  select type(cloud_props_gpt_liq)
+                  class is (ty_optical_props_2str)
+                    sltaussalp  = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt) * &
+                                      cloud_props_gpt_liq%ssa(isub,LCLDLM:LM,igpt))
+                    sltaussaglp = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt) * &
+                                      cloud_props_gpt_liq%ssa(isub,LCLDLM:LM,igpt) * &
+                                      cloud_props_gpt_liq%g  (isub,LCLDLM:LM,igpt))
+                    sltaussaflp = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt) * &
+                                      cloud_props_gpt_liq%ssa(isub,LCLDLM:LM,igpt) * &
+                                                      forwliq(isub,LCLDLM:LM,igpt))
+                  end select
+                  CDSLDLP(icol) = CDSLDLP(icol) + wgt
+                  CDSLNLP(icol) = CDSLNLP(icol) + wgt * sltaulp
+                  SDSLDLP(icol) = SDSLDLP(icol) + wgt * sltaulp
+                  SDSLNLP(icol) = SDSLNLP(icol) + wgt * sltaussalp
+                  ADSLDLP(icol) = ADSLDLP(icol) + wgt * sltaussalp
+                  ADSLNLP(icol) = ADSLNLP(icol) + wgt * sltaussaglp
+                  FORLDLP(icol) = FORLDLP(icol) + wgt * sltaussalp
+                  FORLNLP(icol) = FORLNLP(icol) + wgt * sltaussaflp
+                end if
+                sitaussalp = 0.; sitaussaglp = 0.; sitaussaflp = 0.
+                if (sitaulp > 0.) then
+                  select type(cloud_props_gpt_ice)
+                  class is (ty_optical_props_2str)
+                    sitaussalp  = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt) * &
+                                      cloud_props_gpt_ice%ssa(isub,LCLDLM:LM,igpt))
+                    sitaussaglp = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt) * &
+                                      cloud_props_gpt_ice%ssa(isub,LCLDLM:LM,igpt) * &
+                                      cloud_props_gpt_ice%g  (isub,LCLDLM:LM,igpt))
+                    sitaussaflp = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt) * &
+                                      cloud_props_gpt_ice%ssa(isub,LCLDLM:LM,igpt) * &
+                                                      forwice(isub,LCLDLM:LM,igpt))
+                  end select
+                  CDSIDLP(icol) = CDSIDLP(icol) + wgt
+                  CDSINLP(icol) = CDSINLP(icol) + wgt * sitaulp
+                  SDSIDLP(icol) = SDSIDLP(icol) + wgt * sitaulp
+                  SDSINLP(icol) = SDSINLP(icol) + wgt * sitaussalp
+                  ADSIDLP(icol) = ADSIDLP(icol) + wgt * sitaussalp
+                  ADSINLP(icol) = ADSINLP(icol) + wgt * sitaussaglp
+                  FORIDLP(icol) = FORIDLP(icol) + wgt * sitaussalp
+                  FORINLP(icol) = FORINLP(icol) + wgt * sitaussaflp
+                end if
+
+                ! mid pressure layer
+                sltaump = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt))
+                sitaump = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt))
+                staump = sltaump + sitaump
+                if (staump > 0.) then
+                  CDSNMP(icol) = CDSNMP(icol) + wgt * staump
+                  CDSDMP(icol) = CDSDMP(icol) + wgt
+                end if
+                sltaussamp = 0.; sltaussagmp = 0.; sltaussafmp = 0.
+                if (sltaump > 0.) then
+                  select type(cloud_props_gpt_liq)
+                  class is (ty_optical_props_2str)
+                    sltaussamp  = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                      cloud_props_gpt_liq%ssa(isub,LCLDMH:LCLDLM-1,igpt))
+                    sltaussagmp = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                      cloud_props_gpt_liq%ssa(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                      cloud_props_gpt_liq%g  (isub,LCLDMH:LCLDLM-1,igpt))
+                    sltaussafmp = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                      cloud_props_gpt_liq%ssa(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                                      forwliq(isub,LCLDMH:LCLDLM-1,igpt))
+                  end select
+                  CDSLDMP(icol) = CDSLDMP(icol) + wgt
+                  CDSLNMP(icol) = CDSLNMP(icol) + wgt * sltaump
+                  SDSLDMP(icol) = SDSLDMP(icol) + wgt * sltaump
+                  SDSLNMP(icol) = SDSLNMP(icol) + wgt * sltaussamp
+                  ADSLDMP(icol) = ADSLDMP(icol) + wgt * sltaussamp
+                  ADSLNMP(icol) = ADSLNMP(icol) + wgt * sltaussagmp
+                  FORLDMP(icol) = FORLDMP(icol) + wgt * sltaussamp
+                  FORLNMP(icol) = FORLNMP(icol) + wgt * sltaussafmp
+                end if
+                sitaussamp = 0.; sitaussagmp = 0.; sitaussafmp = 0.
+                if (sitaump > 0.) then
+                  select type(cloud_props_gpt_ice)
+                  class is (ty_optical_props_2str)
+                    sitaussamp  = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                      cloud_props_gpt_ice%ssa(isub,LCLDMH:LCLDLM-1,igpt))
+                    sitaussagmp = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                      cloud_props_gpt_ice%ssa(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                      cloud_props_gpt_ice%g  (isub,LCLDMH:LCLDLM-1,igpt))
+                    sitaussafmp = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                      cloud_props_gpt_ice%ssa(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                                      forwice(isub,LCLDMH:LCLDLM-1,igpt))
+                  end select
+                  CDSIDMP(icol) = CDSIDMP(icol) + wgt
+                  CDSINMP(icol) = CDSINMP(icol) + wgt * sitaump
+                  SDSIDMP(icol) = SDSIDMP(icol) + wgt * sitaump
+                  SDSINMP(icol) = SDSINMP(icol) + wgt * sitaussamp
+                  ADSIDMP(icol) = ADSIDMP(icol) + wgt * sitaussamp
+                  ADSINMP(icol) = ADSINMP(icol) + wgt * sitaussagmp
+                  FORIDMP(icol) = FORIDMP(icol) + wgt * sitaussamp
+                  FORINMP(icol) = FORINMP(icol) + wgt * sitaussafmp
+                end if
+
+                ! high pressure layer
+                sltauhp = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt))
+                sitauhp = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt))
+                stauhp = sltauhp + sitauhp
+                if (stauhp > 0.) then
+                  CDSNHP(icol) = CDSNHP(icol) + wgt * stauhp
+                  CDSDHP(icol) = CDSDHP(icol) + wgt
+                end if
+                sltaussahp = 0.; sltaussaghp = 0.; sltaussafhp = 0.
+                if (sltauhp > 0.) then
+                  select type(cloud_props_gpt_liq)
+                  class is (ty_optical_props_2str)
+                    sltaussahp  = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt) * &
+                                      cloud_props_gpt_liq%ssa(isub,1:LCLDMH-1,igpt))
+                    sltaussaghp = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt) * &
+                                      cloud_props_gpt_liq%ssa(isub,1:LCLDMH-1,igpt) * &
+                                      cloud_props_gpt_liq%g  (isub,1:LCLDMH-1,igpt))
+                    sltaussafhp = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt) * &
+                                      cloud_props_gpt_liq%ssa(isub,1:LCLDMH-1,igpt) * &
+                                                      forwliq(isub,1:LCLDMH-1,igpt))
+                  end select
+                  CDSLDHP(icol) = CDSLDHP(icol) + wgt
+                  CDSLNHP(icol) = CDSLNHP(icol) + wgt * sltauhp
+                  SDSLDHP(icol) = SDSLDHP(icol) + wgt * sltauhp
+                  SDSLNHP(icol) = SDSLNHP(icol) + wgt * sltaussahp
+                  ADSLDHP(icol) = ADSLDHP(icol) + wgt * sltaussahp
+                  ADSLNHP(icol) = ADSLNHP(icol) + wgt * sltaussaghp
+                  FORLDHP(icol) = FORLDHP(icol) + wgt * sltaussahp
+                  FORLNHP(icol) = FORLNHP(icol) + wgt * sltaussafhp
+                end if
+                sitaussahp = 0.; sitaussaghp = 0.; sitaussafhp = 0.
+                if (sitauhp > 0.) then
+                  select type(cloud_props_gpt_ice)
+                  class is (ty_optical_props_2str)
+                    sitaussahp  = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt) * &
+                                      cloud_props_gpt_ice%ssa(isub,1:LCLDMH-1,igpt))
+                    sitaussaghp = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt) * &
+                                      cloud_props_gpt_ice%ssa(isub,1:LCLDMH-1,igpt) * &
+                                      cloud_props_gpt_ice%g  (isub,1:LCLDMH-1,igpt))
+                    sitaussafhp = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt) * &
+                                      cloud_props_gpt_ice%ssa(isub,1:LCLDMH-1,igpt) * &
+                                                      forwice(isub,1:LCLDMH-1,igpt))
+                  end select
+                  CDSIDHP(icol) = CDSIDHP(icol) + wgt
+                  CDSINHP(icol) = CDSINHP(icol) + wgt * sitauhp
+                  SDSIDHP(icol) = SDSIDHP(icol) + wgt * sitauhp
+                  SDSINHP(icol) = SDSINHP(icol) + wgt * sitaussahp
+                  ADSIDHP(icol) = ADSIDHP(icol) + wgt * sitaussahp
+                  ADSINHP(icol) = ADSINHP(icol) + wgt * sitaussaghp
+                  FORIDHP(icol) = FORIDHP(icol) + wgt * sitaussahp
+                  FORINHP(icol) = FORINHP(icol) + wgt * sitaussafhp
+                end if
+
+                ! whole subcolumn
+                sltautp = sltaulp + sltaump + sltauhp
+                sitautp = sitaulp + sitaump + sitauhp
+                stautp  = staulp  + staump  + stauhp
+                if (stautp > 0.) then
+                  CDSNTP(icol) = CDSNTP(icol) + wgt * stautp
+                  CDSDTP(icol) = CDSDTP(icol) + wgt
+                end if
+                sltaussatp  = sltaussalp  + sltaussamp  + sltaussahp
+                sltaussagtp = sltaussaglp + sltaussagmp + sltaussaghp
+                sltaussaftp = sltaussaflp + sltaussafmp + sltaussafhp
+                if (sltautp > 0.) then
+                  CDSLDTP(icol) = CDSLDTP(icol) + wgt
+                  CDSLNTP(icol) = CDSLNTP(icol) + wgt * sltautp
+                  SDSLDTP(icol) = SDSLDTP(icol) + wgt * sltautp
+                  SDSLNTP(icol) = SDSLNTP(icol) + wgt * sltaussatp
+                  ADSLDTP(icol) = ADSLDTP(icol) + wgt * sltaussatp
+                  ADSLNTP(icol) = ADSLNTP(icol) + wgt * sltaussagtp
+                  FORLDTP(icol) = FORLDTP(icol) + wgt * sltaussatp
+                  FORLNTP(icol) = FORLNTP(icol) + wgt * sltaussaftp
+                end if
+                sitaussatp  = sitaussalp  + sitaussamp  + sitaussahp
+                sitaussagtp = sitaussaglp + sitaussagmp + sitaussaghp
+                sitaussaftp = sitaussaflp + sitaussafmp + sitaussafhp
+                if (sitautp > 0.) then
+                  CDSIDTP(icol) = CDSIDTP(icol) + wgt
+                  CDSINTP(icol) = CDSINTP(icol) + wgt * sitautp
+                  SDSIDTP(icol) = SDSIDTP(icol) + wgt * sitautp
+                  SDSINTP(icol) = SDSINTP(icol) + wgt * sitaussatp
+                  ADSIDTP(icol) = ADSIDTP(icol) + wgt * sitaussatp
+                  ADSINTP(icol) = ADSINTP(icol) + wgt * sitaussagtp
+                  FORIDTP(icol) = FORIDTP(icol) + wgt * sitaussatp
+                  FORINTP(icol) = FORINTP(icol) + wgt * sitaussaftp
+                end if
+
+              end do ! igpt
+            end do ! ib
+
+          end if  ! potentially cloudy column
+        end do  ! isub
+      end if  ! include_aerosols
+
+      call MAPL_TimerOff(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
+
+      RETURN_(ESMF_SUCCESS)
+
+    end subroutine compute_sprlyr_diags_postdelta
 #undef TEST_
 
 

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -7118,7 +7118,7 @@ contains
 #define TEST_(A) error_msg = A; if (trim(error_msg)/="") then; _FAIL("RRTMGP Error: "//trim(error_msg)); endif
     subroutine compute_rte_sw( &
         colS, colE, ngpt, &
-        tsi, toa_flux, need_aer_optical_props, aer_props, optical_props, &
+        tsi, toa_flux, optical_props, &
         top_at_1, mu0, sfc_alb_dir, sfc_alb_dif, &
         fluxes_clrsky, flux_up_clrsky, flux_net_clrsky, &
         fluxes_allsky, flux_up_allsky, flux_net_allsky, &
@@ -7134,8 +7134,6 @@ contains
       integer,                              intent(in)    :: colS, colE, ngpt
       real(wp),                             intent(in)    :: tsi(:)
       real(wp),                             intent(inout) :: toa_flux(:,:)
-      logical,                              intent(in)    :: need_aer_optical_props
-      class(ty_optical_props_arry),         intent(inout) :: aer_props
       class(ty_optical_props_arry),         intent(inout) :: optical_props
       logical,                              intent(in)    :: top_at_1
       real(wp),                             intent(in)    :: mu0(:)
@@ -7164,11 +7162,6 @@ contains
       ! scale to our tsi
       ! (both toa_flux and tsi are NORMAL to solar beam, [W/m2])
       toa_flux = toa_flux * spread(tsi(colS:colE)/sum(toa_flux,dim=2), 2, ngpt)
-
-      ! add in aerosol optical properties if requested and available
-      if (need_aer_optical_props) then
-        TEST_(aer_props%increment(optical_props))
-      end if
 
       ! clear-sky radiative transfer
       fluxes_clrsky%flux_up  => flux_up_clrsky
@@ -7514,9 +7507,16 @@ contains
         MAPL, __RC__)
 #endif
 
+      ! add in aerosol optical properties if requested and available
+      ! (done here rather than inside compute_rte_sw to avoid passing
+      !  an unallocated polymorphic aer_props when aerosols are inactive)
+      if (need_aer_optical_props) then
+        TEST_(aer_props%increment(optical_props))
+      end if
+
       call compute_rte_sw( &
         colS, colE, ngpt, &
-        tsi, toa_flux, need_aer_optical_props, aer_props, optical_props, &
+        tsi, toa_flux, optical_props, &
         top_at_1, mu0, sfc_alb_dir, sfc_alb_dif, &
         fluxes_clrsky, flux_up_clrsky(colS:colE,:), flux_net_clrsky(colS:colE,:), &
         fluxes_allsky, flux_up_allsky(colS:colE,:), flux_net_allsky(colS:colE,:), &

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -5325,69 +5325,13 @@ contains
 
 
         ! delta-scaling of cloud optical properties (accounts for forward scattering)
-        call MAPL_TimerOn(MAPL,"--RRTMGP_DELTA_SCALE",__RC__)
-        forwliq = 0.; forwice = 0.  ! default for no delta-scaling
-        if (rrtmgp_delta_scale) then
-
-          ! default delta-scaling for liquid
-          select type(cloud_props_gpt_liq)
-          class is (ty_optical_props_2str)
-            forwliq = cloud_props_gpt_liq%g ** 2
-          end select
-          TEST_(cloud_props_gpt_liq%delta_scale(forwliq))
-
-          if (rrtmgp_use_rrtmg_iceflg3_like_forwice) then
-            ! non-default delta-scaling for ice (as in RRTMG iceflag==3)
-            select type(cloud_props_gpt_ice)
-            class is (ty_optical_props_2str)
-              radice_lwr = cloud_optics%get_min_radius_ice()
-              radice_upr = cloud_optics%get_max_radius_ice()
-              do isub = 1,ncols_block
-                icol = colS + isub - 1
-                do ilay = 1,LM
-                  ! only if at least potentially cloudy ...
-                  if (CL(icol,ilay) > 0.) then
-  
-                    ! prepare for radice interpolation ...
-                    ! first get radice consistent with RRTMGP ice cloud optics
-                    radice = min(max(real(RR3(icol,ilay,1),kind=wp),radice_lwr),radice_upr)
-                    ! now force into RRTMG's iceflag==3 reice binning range [5,140]um.
-                    radice = min(max(radice,5._wp),140._wp)
-                    ! RRTMG has 46 reice bins with 5um->radidx==1, 140um->radidx==46,
-                    ! but radidx is forced to [1,45] so LIN2_ARG1 interpolation works.
-                    radfac = (radice - 2._wp) / 3._wp
-                    radidx = min(max(int(radfac),1),45)
-                    rfint = radfac - real(radidx,kind=wp)
-  
-                    do ib = 1,nbnd
-                      ! interpolate fdelta in radice for band ib
-                      fdelta = LIN2_ARG1(fdlice3_rrtmgp,radidx,ib,rfint)
-  
-                      ! forwice calc for each g-point
-                      do igpt = band_lims_gpt(1,ib),band_lims_gpt(2,ib)
-                        if (cloud_props_gpt_ice%tau(isub,ilay,igpt) > 0.) then
-                          forwice(isub,ilay,igpt) = min( &
-                             fdelta + 0.5_wp / cloud_props_gpt_ice%ssa(isub,ilay,igpt), &
-                             cloud_props_gpt_ice%g(isub,ilay,igpt))
-                        endif
-                      enddo  ! g-points
-                    enddo  ! bands
-  
-                  endif  ! potentially cloudy
-                enddo  ! layers
-              enddo  ! columns
-            end select
-            TEST_(cloud_props_gpt_ice%delta_scale(forwice))
-          else
-            ! default delta-scaling for ice
-            select type(cloud_props_gpt_ice)
-            class is (ty_optical_props_2str)
-              forwice = cloud_props_gpt_ice%g ** 2
-            end select
-            TEST_(cloud_props_gpt_ice%delta_scale(forwice))
-          endif
-        endif
-        call MAPL_TimerOff(MAPL,"--RRTMGP_DELTA_SCALE",__RC__)
+        call compute_delta_scale( &
+          colS, ncols_block, LM, ngpt, nbnd, &
+          rrtmgp_delta_scale, rrtmgp_use_rrtmg_iceflg3_like_forwice, &
+          CL, RR3, band_lims_gpt, &
+          cloud_optics, cloud_props_gpt_liq, cloud_props_gpt_ice, &
+          forwliq, forwice, &
+          MAPL, __RC__)
 
 #ifdef SOLAR_RADVAL
         ! REFRESH super-layer diagnostics (after delta-scaling TAUs).
@@ -7106,6 +7050,113 @@ contains
       RETURN_(ESMF_SUCCESS)
 
     end subroutine compute_sprlyr_diags_predelta
+#undef TEST_
+
+    ! ---------------------------------------------------------------------------
+    ! Delta-scale cloud optical properties (liquid and ice) for one block.
+    ! forwliq and forwice are computed here and returned for use in Step 2f.
+    ! All scalar temporaries are local (thread-private under future OMP).
+    ! ---------------------------------------------------------------------------
+#define TEST_(A) error_msg = A; if (trim(error_msg)/="") then; _FAIL("RRTMGP Error: "//trim(error_msg)); endif
+    subroutine compute_delta_scale( &
+        colS, ncols_block, LM, ngpt, nbnd, &
+        rrtmgp_delta_scale, rrtmgp_use_rrtmg_iceflg3_like_forwice, &
+        CL, RR3, band_lims_gpt, &
+        cloud_optics, cloud_props_gpt_liq, cloud_props_gpt_ice, &
+        forwliq, forwice, &
+        MAPL, RC)
+
+      use mo_optical_props,       only: ty_optical_props_arry, ty_optical_props_2str
+      use mo_cloud_optics_rrtmgp, only: ty_cloud_optics_rrtmgp
+      use mo_rte_kind,            only: wp
+
+      integer,                        intent(in)    :: colS, ncols_block, LM, ngpt, nbnd
+      logical,                        intent(in)    :: rrtmgp_delta_scale
+      logical,                        intent(in)    :: rrtmgp_use_rrtmg_iceflg3_like_forwice
+      real,             dimension(:,:),   intent(in) :: CL
+      real,             dimension(:,:,:), intent(in) :: RR3
+      integer,          dimension(:,:),   intent(in) :: band_lims_gpt
+      type(ty_cloud_optics_rrtmgp),   intent(inout) :: cloud_optics
+      class(ty_optical_props_arry),   intent(inout) :: cloud_props_gpt_liq, cloud_props_gpt_ice
+      real(wp),         dimension(:,:,:), intent(out) :: forwliq, forwice
+      type(MAPL_MetaComp),            intent(inout) :: MAPL
+      integer, optional,              intent(out)   :: RC
+
+      ! locals -- all thread-private under future !$OMP PARALLEL DO
+      integer  :: isub, icol, ilay, ib, igpt, radidx
+      real(wp) :: radice_lwr, radice_upr, radice, radfac, rfint, fdelta
+      character(len=ESMF_MAXSTR) :: error_msg
+      integer  :: STATUS
+
+      call MAPL_TimerOn(MAPL,"--RRTMGP_DELTA_SCALE",__RC__)
+
+      forwliq = 0.; forwice = 0.  ! default for no delta-scaling
+      if (rrtmgp_delta_scale) then
+
+        ! default delta-scaling for liquid
+        select type(cloud_props_gpt_liq)
+        class is (ty_optical_props_2str)
+          forwliq = cloud_props_gpt_liq%g ** 2
+        end select
+        TEST_(cloud_props_gpt_liq%delta_scale(forwliq))
+
+        if (rrtmgp_use_rrtmg_iceflg3_like_forwice) then
+          ! non-default delta-scaling for ice (as in RRTMG iceflag==3)
+          select type(cloud_props_gpt_ice)
+          class is (ty_optical_props_2str)
+            radice_lwr = cloud_optics%get_min_radius_ice()
+            radice_upr = cloud_optics%get_max_radius_ice()
+            do isub = 1,ncols_block
+              icol = colS + isub - 1
+              do ilay = 1,LM
+                ! only if at least potentially cloudy ...
+                if (CL(icol,ilay) > 0.) then
+
+                  ! prepare for radice interpolation ...
+                  ! first get radice consistent with RRTMGP ice cloud optics
+                  radice = min(max(real(RR3(icol,ilay,1),kind=wp),radice_lwr),radice_upr)
+                  ! now force into RRTMG's iceflag==3 reice binning range [5,140]um.
+                  radice = min(max(radice,5._wp),140._wp)
+                  ! RRTMG has 46 reice bins with 5um->radidx==1, 140um->radidx==46,
+                  ! but radidx is forced to [1,45] so LIN2_ARG1 interpolation works.
+                  radfac = (radice - 2._wp) / 3._wp
+                  radidx = min(max(int(radfac),1),45)
+                  rfint = radfac - real(radidx,kind=wp)
+
+                  do ib = 1,nbnd
+                    ! interpolate fdelta in radice for band ib
+                    fdelta = LIN2_ARG1(fdlice3_rrtmgp,radidx,ib,rfint)
+
+                    ! forwice calc for each g-point
+                    do igpt = band_lims_gpt(1,ib),band_lims_gpt(2,ib)
+                      if (cloud_props_gpt_ice%tau(isub,ilay,igpt) > 0.) then
+                        forwice(isub,ilay,igpt) = min( &
+                           fdelta + 0.5_wp / cloud_props_gpt_ice%ssa(isub,ilay,igpt), &
+                           cloud_props_gpt_ice%g(isub,ilay,igpt))
+                      endif
+                    enddo  ! g-points
+                  enddo  ! bands
+
+                endif  ! potentially cloudy
+              enddo  ! layers
+            enddo  ! columns
+          end select
+          TEST_(cloud_props_gpt_ice%delta_scale(forwice))
+        else
+          ! default delta-scaling for ice
+          select type(cloud_props_gpt_ice)
+          class is (ty_optical_props_2str)
+            forwice = cloud_props_gpt_ice%g ** 2
+          end select
+          TEST_(cloud_props_gpt_ice%delta_scale(forwice))
+        endif
+      endif
+
+      call MAPL_TimerOff(MAPL,"--RRTMGP_DELTA_SCALE",__RC__)
+
+      RETURN_(ESMF_SUCCESS)
+
+    end subroutine compute_delta_scale
 #undef TEST_
 
 

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -5297,288 +5297,32 @@ contains
         ! REFRESH super-layer diagnostics (before delta-scaling TAUs).
         ! ** Calculated from subcolumn ensemble, so stochastic **
         ! -------------------------------------------------------
-        call MAPL_TimerOn(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
-        if (include_aerosols) then
-
-          ! super-layer cloud fractions
-          call clearCounts_threeBand( &
-            ncols_block, ncols_block, ngpt, LM, LCLDLM, LCLDMH, &
-            reshape(cld_mask,[LM,ngpt,ncols_block],order=[3,1,2]), &
-            ClearCounts)
-          do isub = 1,ncols_block
-            icol = colS + isub - 1
-            CLDTS(icol) = 1. - ClearCounts(1,isub)/float(ngpt)
-            CLDHS(icol) = 1. - ClearCounts(2,isub)/float(ngpt)
-            CLDMS(icol) = 1. - ClearCounts(3,isub)/float(ngpt)
-            CLDLS(icol) = 1. - ClearCounts(4,isub)/float(ngpt)
-          end do
-
-          ! in-cloud optical thicknesses in PAR super-band
-          ! (weighted across and within bands by TOA incident flux)
-          do isub = 1,ncols_block
-            icol = colS + isub - 1
-
+        call compute_sprlyr_diags_predelta( &
+          colS, ncols_block, LM, ngpt, nbnd, LCLDLM, LCLDMH, &
+          include_aerosols, &
+          cld_mask, ClearCounts, CL, toa_flux, band_lims_gpt, &
+          cloud_props_gpt_liq, cloud_props_gpt_ice, &
+          CLDTS, CLDHS, CLDMS, CLDLS, &
+          COTTP, COTHP, COTMP, COTLP, &
+          COTDTP, COTDHP, COTDMP, COTDLP, &
+          COTNTP, COTNHP, COTNMP, COTNLP, &
 #ifdef SOLAR_RADVAL
-            ! default (no cloud) for TAUx variant 
-            TAUTP(icol) = 0.
-            TAUHP(icol) = 0.
-            TAUMP(icol) = 0.
-            TAULP(icol) = 0.
+          TAUTP, TAUHP, TAUMP, TAULP, &
+          COTLDTP, COTLDHP, COTLDMP, COTLDLP, &
+          COTLNTP, COTLNHP, COTLNMP, COTLNLP, &
+          COTIDTP, COTIDHP, COTIDMP, COTIDLP, &
+          COTINTP, COTINHP, COTINMP, COTINLP, &
+          SSALDTP, SSALDHP, SSALDMP, SSALDLP, &
+          SSALNTP, SSALNHP, SSALNMP, SSALNLP, &
+          SSAIDTP, SSAIDHP, SSAIDMP, SSAIDLP, &
+          SSAINTP, SSAINHP, SSAINMP, SSAINLP, &
+          ASMLDTP, ASMLDHP, ASMLDMP, ASMLDLP, &
+          ASMLNTP, ASMLNHP, ASMLNMP, ASMLNLP, &
+          ASMIDTP, ASMIDHP, ASMIDMP, ASMIDLP, &
+          ASMINTP, ASMINHP, ASMINMP, ASMINLP, &
 #endif
+          MAPL, __RC__)
 
-            ! default (no cloud) for COTx variant
-            COTTP(icol) = MAPL_UNDEF
-            COTHP(icol) = MAPL_UNDEF
-            COTMP(icol) = MAPL_UNDEF
-            COTLP(icol) = MAPL_UNDEF
-
-            ! zero denom- and numerator accumulators
-            COTDTP(icol) = 0.; COTNTP(icol) = 0.
-            COTDHP(icol) = 0.; COTNHP(icol) = 0.
-            COTDMP(icol) = 0.; COTNMP(icol) = 0.
-            COTDLP(icol) = 0.; COTNLP(icol) = 0.
-#ifdef SOLAR_RADVAL
-            COTLDTP(icol) = 0.; COTLNTP(icol) = 0.; COTIDTP(icol) = 0.; COTINTP(icol) = 0.
-            COTLDHP(icol) = 0.; COTLNHP(icol) = 0.; COTIDHP(icol) = 0.; COTINHP(icol) = 0.
-            COTLDMP(icol) = 0.; COTLNMP(icol) = 0.; COTIDMP(icol) = 0.; COTINMP(icol) = 0.
-            COTLDLP(icol) = 0.; COTLNLP(icol) = 0.; COTIDLP(icol) = 0.; COTINLP(icol) = 0.
-            SSALDTP(icol) = 0.; SSALNTP(icol) = 0.; SSAIDTP(icol) = 0.; SSAINTP(icol) = 0.
-            SSALDHP(icol) = 0.; SSALNHP(icol) = 0.; SSAIDHP(icol) = 0.; SSAINHP(icol) = 0.
-            SSALDMP(icol) = 0.; SSALNMP(icol) = 0.; SSAIDMP(icol) = 0.; SSAINMP(icol) = 0.
-            SSALDLP(icol) = 0.; SSALNLP(icol) = 0.; SSAIDLP(icol) = 0.; SSAINLP(icol) = 0.
-            ASMLDTP(icol) = 0.; ASMLNTP(icol) = 0.; ASMIDTP(icol) = 0.; ASMINTP(icol) = 0.
-            ASMLDHP(icol) = 0.; ASMLNHP(icol) = 0.; ASMIDHP(icol) = 0.; ASMINHP(icol) = 0.
-            ASMLDMP(icol) = 0.; ASMLNMP(icol) = 0.; ASMIDMP(icol) = 0.; ASMINMP(icol) = 0.
-            ASMLDLP(icol) = 0.; ASMLNLP(icol) = 0.; ASMIDLP(icol) = 0.; ASMINLP(icol) = 0.
-#endif
-
-            ! can only be non-zero for potentially cloudy columns
-            if (any(CL(icol,:) > 0.)) then
-
-              ! accumulate over gpts/subcolumns
-              do ib = 1, nbnd
-                do igpt = band_lims_gpt(1,ib), band_lims_gpt(2,ib)
-       
-                  ! band weights for photosynthetically active radiation (PAR)
-                  ! Bands 11-12 (0.345-0.625 um) plus half transition band 10 (0.625-0.778 um)
-                  if (ib >= 11 .and. ib <= 12) then
-                    wgt = 1.0
-                  else if (ib == 10) then
-                    wgt = 0.5
-                  else
-                    ! no contribution to PAR
-                    cycle
-                  end if
-
-                  ! TOA flux weighting
-                  ! (note: neither the adjustment of toa_flux to our tsi
-                  ! or for zenith angle are needed yet since this weighting
-                  ! is over gpoint and is normalized for EACH icol)
-                  wgt = wgt * toa_flux(isub,igpt)
-
-                  ! low pressure layer
-                  sltaulp = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt))
-                  sitaulp = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt))
-                  staulp = sltaulp + sitaulp
-                  if (staulp > 0.) then
-                    COTDLP(icol) = COTDLP(icol) + wgt
-                    COTNLP(icol) = COTNLP(icol) + wgt * staulp
-                  end if
-#ifdef SOLAR_RADVAL
-                  sltaussalp = 0.; sltaussaglp = 0.
-                  if (sltaulp > 0.) then
-                    select type(cloud_props_gpt_liq)
-                    class is (ty_optical_props_2str)
-                      sltaussalp = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt) * &
-                                       cloud_props_gpt_liq%ssa(isub,LCLDLM:LM,igpt))
-                      sltaussaglp = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt) * &
-                                        cloud_props_gpt_liq%ssa(isub,LCLDLM:LM,igpt) * &
-                                        cloud_props_gpt_liq%g  (isub,LCLDLM:LM,igpt))
-                    end select
-                    COTLDLP(icol) = COTLDLP(icol) + wgt
-                    COTLNLP(icol) = COTLNLP(icol) + wgt * sltaulp
-                    SSALDLP(icol) = SSALDLP(icol) + wgt * sltaulp
-                    SSALNLP(icol) = SSALNLP(icol) + wgt * sltaussalp
-                    ASMLDLP(icol) = ASMLDLP(icol) + wgt * sltaussalp
-                    ASMLNLP(icol) = ASMLNLP(icol) + wgt * sltaussaglp
-                  end if
-                  sitaussalp = 0.; sitaussaglp = 0.
-                  if (sitaulp > 0.) then
-                    select type(cloud_props_gpt_ice)
-                    class is (ty_optical_props_2str)
-                      sitaussalp = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt) * &
-                                       cloud_props_gpt_ice%ssa(isub,LCLDLM:LM,igpt))
-                      sitaussaglp = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt) * &
-                                        cloud_props_gpt_ice%ssa(isub,LCLDLM:LM,igpt) * &
-                                        cloud_props_gpt_ice%g  (isub,LCLDLM:LM,igpt))
-                    end select
-                    COTIDLP(icol) = COTIDLP(icol) + wgt
-                    COTINLP(icol) = COTINLP(icol) + wgt * sitaulp
-                    SSAIDLP(icol) = SSAIDLP(icol) + wgt * sitaulp
-                    SSAINLP(icol) = SSAINLP(icol) + wgt * sitaussalp
-                    ASMIDLP(icol) = ASMIDLP(icol) + wgt * sitaussalp
-                    ASMINLP(icol) = ASMINLP(icol) + wgt * sitaussaglp
-                  end if
-#endif
-
-                  ! mid pressure layer
-                  sltaump = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt))
-                  sitaump = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt))
-                  staump = sltaump + sitaump
-                  if (staump > 0.) then
-                    COTDMP(icol) = COTDMP(icol) + wgt
-                    COTNMP(icol) = COTNMP(icol) + wgt * staump
-                  end if
-#ifdef SOLAR_RADVAL
-                  sltaussamp = 0.; sltaussagmp = 0.
-                  if (sltaump > 0.) then
-                    select type(cloud_props_gpt_liq)
-                    class is (ty_optical_props_2str)
-                      sltaussamp = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                       cloud_props_gpt_liq%ssa(isub,LCLDMH:LCLDLM-1,igpt))
-                      sltaussagmp = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                        cloud_props_gpt_liq%ssa(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                        cloud_props_gpt_liq%g  (isub,LCLDMH:LCLDLM-1,igpt))
-                    end select
-                    COTLDMP(icol) = COTLDMP(icol) + wgt
-                    COTLNMP(icol) = COTLNMP(icol) + wgt * sltaump
-                    SSALDMP(icol) = SSALDMP(icol) + wgt * sltaump
-                    SSALNMP(icol) = SSALNMP(icol) + wgt * sltaussamp
-                    ASMLDMP(icol) = ASMLDMP(icol) + wgt * sltaussamp
-                    ASMLNMP(icol) = ASMLNMP(icol) + wgt * sltaussagmp
-                  end if
-                  sitaussamp = 0.; sitaussagmp = 0.
-                  if (sitaump > 0.) then
-                    select type(cloud_props_gpt_ice)
-                    class is (ty_optical_props_2str)
-                      sitaussamp = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                       cloud_props_gpt_ice%ssa(isub,LCLDMH:LCLDLM-1,igpt))
-                      sitaussagmp = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                        cloud_props_gpt_ice%ssa(isub,LCLDMH:LCLDLM-1,igpt) * &
-                                        cloud_props_gpt_ice%g  (isub,LCLDMH:LCLDLM-1,igpt))
-                    end select
-                    COTIDMP(icol) = COTIDMP(icol) + wgt
-                    COTINMP(icol) = COTINMP(icol) + wgt * sitaump
-                    SSAIDMP(icol) = SSAIDMP(icol) + wgt * sitaump
-                    SSAINMP(icol) = SSAINMP(icol) + wgt * sitaussamp
-                    ASMIDMP(icol) = ASMIDMP(icol) + wgt * sitaussamp
-                    ASMINMP(icol) = ASMINMP(icol) + wgt * sitaussagmp
-                  end if
-#endif
-
-                  ! high pressure layer
-                  sltauhp = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt))
-                  sitauhp = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt))
-                  stauhp = sltauhp + sitauhp
-                  if (stauhp > 0.) then
-                    COTDHP(icol) = COTDHP(icol) + wgt
-                    COTNHP(icol) = COTNHP(icol) + wgt * stauhp
-                  end if
-#ifdef SOLAR_RADVAL
-                  sltaussahp = 0.; sltaussaghp = 0.
-                  if (sltauhp > 0.) then
-                    select type(cloud_props_gpt_liq)
-                    class is (ty_optical_props_2str)
-                      sltaussahp = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt) * &
-                                       cloud_props_gpt_liq%ssa(isub,1:LCLDMH-1,igpt))
-                      sltaussaghp = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt) * &
-                                        cloud_props_gpt_liq%ssa(isub,1:LCLDMH-1,igpt) * &
-                                        cloud_props_gpt_liq%g  (isub,1:LCLDMH-1,igpt))
-                    end select
-                    COTLDHP(icol) = COTLDHP(icol) + wgt
-                    COTLNHP(icol) = COTLNHP(icol) + wgt * sltauhp
-                    SSALDHP(icol) = SSALDHP(icol) + wgt * sltauhp
-                    SSALNHP(icol) = SSALNHP(icol) + wgt * sltaussahp
-                    ASMLDHP(icol) = ASMLDHP(icol) + wgt * sltaussahp
-                    ASMLNHP(icol) = ASMLNHP(icol) + wgt * sltaussaghp
-                  end if
-                  sitaussahp = 0.; sitaussaghp = 0.
-                  if (sitauhp > 0.) then
-                    select type(cloud_props_gpt_ice)
-                    class is (ty_optical_props_2str)
-                      sitaussahp = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt) * &
-                                       cloud_props_gpt_ice%ssa(isub,1:LCLDMH-1,igpt))
-                      sitaussaghp = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt) * &
-                                        cloud_props_gpt_ice%ssa(isub,1:LCLDMH-1,igpt) * &
-                                        cloud_props_gpt_ice%g  (isub,1:LCLDMH-1,igpt))
-                    end select
-                    COTIDHP(icol) = COTIDHP(icol) + wgt
-                    COTINHP(icol) = COTINHP(icol) + wgt * sitauhp
-                    SSAIDHP(icol) = SSAIDHP(icol) + wgt * sitauhp
-                    SSAINHP(icol) = SSAINHP(icol) + wgt * sitaussahp
-                    ASMIDHP(icol) = ASMIDHP(icol) + wgt * sitaussahp
-                    ASMINHP(icol) = ASMINHP(icol) + wgt * sitaussaghp
-                  end if
-#endif
-
-                  ! whole subcolumn
-                  sltautp = sltaulp + sltaump + sltauhp
-                  sitautp = sitaulp + sitaump + sitauhp
-                  stautp = staulp + staump + stauhp
-                  if (stautp > 0.) then
-                    COTDTP(icol) = COTDTP(icol) + wgt
-                    COTNTP(icol) = COTNTP(icol) + wgt * stautp
-                  end if
-#ifdef SOLAR_RADVAL
-                  sltaussatp = sltaussalp + sltaussamp + sltaussahp
-                  sltaussagtp = sltaussaglp + sltaussagmp + sltaussaghp
-                  if (sltautp > 0.) then
-                    COTLDTP(icol) = COTLDTP(icol) + wgt
-                    COTLNTP(icol) = COTLNTP(icol) + wgt * sltautp
-                    SSALDTP(icol) = SSALDTP(icol) + wgt * sltautp
-                    SSALNTP(icol) = SSALNTP(icol) + wgt * sltaussatp
-                    ASMLDTP(icol) = ASMLDTP(icol) + wgt * sltaussatp
-                    ASMLNTP(icol) = ASMLNTP(icol) + wgt * sltaussagtp
-                  end if
-                  sitaussatp = sitaussalp + sitaussamp + sitaussahp
-                  sitaussagtp = sitaussaglp + sitaussagmp + sitaussaghp
-                  if (sitautp > 0.) then
-                    COTIDTP(icol) = COTIDTP(icol) + wgt
-                    COTINTP(icol) = COTINTP(icol) + wgt * sitautp
-                    SSAIDTP(icol) = SSAIDTP(icol) + wgt * sitautp
-                    SSAINTP(icol) = SSAINTP(icol) + wgt * sitaussatp
-                    ASMIDTP(icol) = ASMIDTP(icol) + wgt * sitaussatp
-                    ASMINTP(icol) = ASMINTP(icol) + wgt * sitaussagtp
-                  end if
-#endif
-
-                end do ! igpt
-              end do ! ib
-
-              ! normalize
-              ! Note: TAUx defaults zero, COTx defaults MAPL_UNDEF
-              if (COTDTP(icol) > 0. .and. COTNTP(icol) > 0.) then
-                COTTP(icol) = COTNTP(icol) / COTDTP(icol)
-#ifdef SOLAR_RADVAL
-                TAUTP(icol) = COTTP(icol)
-#endif
-              end if
-
-              if (COTDHP(icol) > 0. .and. COTNHP(icol) > 0.) then
-                COTHP(icol) = COTNHP(icol) / COTDHP(icol)
-#ifdef SOLAR_RADVAL
-                TAUHP(icol) = COTHP(icol)
-#endif
-              end if
-
-              if (COTDMP(icol) > 0. .and. COTNMP(icol) > 0.) then
-                COTMP(icol) = COTNMP(icol) / COTDMP(icol)
-#ifdef SOLAR_RADVAL
-                TAUMP(icol) = COTMP(icol)
-#endif
-              end if
-
-              if (COTDLP(icol) > 0. .and. COTNLP(icol) > 0.) then
-                COTLP(icol) = COTNLP(icol) / COTDLP(icol)
-#ifdef SOLAR_RADVAL
-                TAULP(icol) = COTLP(icol)
-#endif
-              end if
-
-            end if  ! potentially cloudy column 
-          end do  ! isub
-        end if  ! include_aerosols
-        call MAPL_TimerOff(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
 
         ! delta-scaling of cloud optical properties (accounts for forward scattering)
         call MAPL_TimerOn(MAPL,"--RRTMGP_DELTA_SCALE",__RC__)
@@ -6652,7 +6396,7 @@ contains
 
       use mo_gas_concentrations, only: ty_gas_concs
       use mo_gas_optics_rrtmgp,  only: ty_gas_optics_rrtmgp
-      use mo_optical_props,      only: ty_optical_props_arry
+      use mo_optical_props, only: ty_optical_props_arry, ty_optical_props_2str
       use mo_rte_kind,           only: wp
 
       integer,                           intent(in)    :: colS, colE, ncols_block, LM
@@ -6992,6 +6736,376 @@ contains
       RETURN_(ESMF_SUCCESS)
 
     end subroutine compute_cloud_optics_mcica
+#undef TEST_
+
+    ! ---------------------------------------------------------------------------
+    ! Super-layer cloud fraction and in-cloud optical depth diagnostics,
+    ! computed from the McICA subcolumn ensemble BEFORE delta-scaling.
+    ! All scalar temporaries are local (thread-private under future OMP).
+    ! ---------------------------------------------------------------------------
+#define TEST_(A) error_msg = A; if (trim(error_msg)/="") then; _FAIL("RRTMGP Error: "//trim(error_msg)); endif
+    subroutine compute_sprlyr_diags_predelta( &
+        colS, ncols_block, LM, ngpt, nbnd, LCLDLM, LCLDMH, &
+        include_aerosols, &
+        cld_mask, ClearCounts, CL, toa_flux, band_lims_gpt, &
+        cloud_props_gpt_liq, cloud_props_gpt_ice, &
+        CLDTS, CLDHS, CLDMS, CLDLS, &
+        COTTP, COTHP, COTMP, COTLP, &
+        COTDTP, COTDHP, COTDMP, COTDLP, &
+        COTNTP, COTNHP, COTNMP, COTNLP, &
+#ifdef SOLAR_RADVAL
+        TAUTP, TAUHP, TAUMP, TAULP, &
+        COTLDTP, COTLDHP, COTLDMP, COTLDLP, &
+        COTLNTP, COTLNHP, COTLNMP, COTLNLP, &
+        COTIDTP, COTIDHP, COTIDMP, COTIDLP, &
+        COTINTP, COTINHP, COTINMP, COTINLP, &
+        SSALDTP, SSALDHP, SSALDMP, SSALDLP, &
+        SSALNTP, SSALNHP, SSALNMP, SSALNLP, &
+        SSAIDTP, SSAIDHP, SSAIDMP, SSAIDLP, &
+        SSAINTP, SSAINHP, SSAINMP, SSAINLP, &
+        ASMLDTP, ASMLDHP, ASMLDMP, ASMLDLP, &
+        ASMLNTP, ASMLNHP, ASMLNMP, ASMLNLP, &
+        ASMIDTP, ASMIDHP, ASMIDMP, ASMIDLP, &
+        ASMINTP, ASMINHP, ASMINMP, ASMINLP, &
+#endif
+        MAPL, RC)
+
+      use mo_optical_props, only: ty_optical_props_arry
+
+      integer,                      intent(in)    :: colS, ncols_block, LM, ngpt, nbnd
+      integer,                      intent(in)    :: LCLDLM, LCLDMH
+      logical,                      intent(in)    :: include_aerosols
+      logical,          intent(in)  :: cld_mask(:,:,:)
+      integer,          intent(inout) :: ClearCounts(:,:)
+      real,             intent(in)  :: CL(:,:)
+      real(wp),         intent(in)  :: toa_flux(:,:)
+      integer,          intent(in)  :: band_lims_gpt(:,:)
+      class(ty_optical_props_arry), intent(in) :: cloud_props_gpt_liq, cloud_props_gpt_ice
+      real,             intent(inout) :: CLDTS(:), CLDHS(:), CLDMS(:), CLDLS(:)
+      real,             intent(inout) :: COTTP(:), COTHP(:), COTMP(:), COTLP(:)
+      real,             intent(inout) :: COTDTP(:), COTDHP(:), COTDMP(:), COTDLP(:)
+      real,             intent(inout) :: COTNTP(:), COTNHP(:), COTNMP(:), COTNLP(:)
+#ifdef SOLAR_RADVAL
+      real,             intent(inout) :: TAUTP(:), TAUHP(:), TAUMP(:), TAULP(:)
+      real,             intent(inout) :: COTLDTP(:), COTLDHP(:), COTLDMP(:), COTLDLP(:)
+      real,             intent(inout) :: COTLNTP(:), COTLNHP(:), COTLNMP(:), COTLNLP(:)
+      real,             intent(inout) :: COTIDTP(:), COTIDHP(:), COTIDMP(:), COTIDLP(:)
+      real,             intent(inout) :: COTINTP(:), COTINHP(:), COTINMP(:), COTINLP(:)
+      real,             intent(inout) :: SSALDTP(:), SSALDHP(:), SSALDMP(:), SSALDLP(:)
+      real,             intent(inout) :: SSALNTP(:), SSALNHP(:), SSALNMP(:), SSALNLP(:)
+      real,             intent(inout) :: SSAIDTP(:), SSAIDHP(:), SSAIDMP(:), SSAIDLP(:)
+      real,             intent(inout) :: SSAINTP(:), SSAINHP(:), SSAINMP(:), SSAINLP(:)
+      real,             intent(inout) :: ASMLDTP(:), ASMLDHP(:), ASMLDMP(:), ASMLDLP(:)
+      real,             intent(inout) :: ASMLNTP(:), ASMLNHP(:), ASMLNMP(:), ASMLNLP(:)
+      real,             intent(inout) :: ASMIDTP(:), ASMIDHP(:), ASMIDMP(:), ASMIDLP(:)
+      real,             intent(inout) :: ASMINTP(:), ASMINHP(:), ASMINMP(:), ASMINLP(:)
+#endif
+      type(MAPL_MetaComp),          intent(inout) :: MAPL
+      integer, optional,            intent(out)   :: RC
+
+      ! locals -- all thread-private under future !$OMP PARALLEL DO
+      integer  :: isub, icol, ib, igpt
+      real     :: wgt
+      real     :: stautp, stauhp, staump, staulp
+      real     :: sltautp, sltauhp, sltaump, sltaulp
+      real     :: sitautp, sitauhp, sitaump, sitaulp
+#ifdef SOLAR_RADVAL
+      real     :: sltaussatp, sltaussahp, sltaussamp, sltaussalp
+      real     :: sitaussatp, sitaussahp, sitaussamp, sitaussalp
+      real     :: sltaussagtp, sltaussaghp, sltaussagmp, sltaussaglp
+      real     :: sitaussagtp, sitaussaghp, sitaussagmp, sitaussaglp
+#endif
+      character(len=ESMF_MAXSTR) :: error_msg
+      integer  :: STATUS
+
+      call MAPL_TimerOn(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
+
+      if (include_aerosols) then
+
+        ! super-layer cloud fractions
+        call clearCounts_threeBand( &
+          ncols_block, ncols_block, ngpt, LM, LCLDLM, LCLDMH, &
+          reshape(cld_mask,[LM,ngpt,ncols_block],order=[3,1,2]), &
+          ClearCounts)
+        do isub = 1,ncols_block
+          icol = colS + isub - 1
+          CLDTS(icol) = 1. - ClearCounts(1,isub)/float(ngpt)
+          CLDHS(icol) = 1. - ClearCounts(2,isub)/float(ngpt)
+          CLDMS(icol) = 1. - ClearCounts(3,isub)/float(ngpt)
+          CLDLS(icol) = 1. - ClearCounts(4,isub)/float(ngpt)
+        end do
+
+          ! in-cloud optical thicknesses in PAR super-band
+          ! (weighted across and within bands by TOA incident flux)
+          do isub = 1,ncols_block
+            icol = colS + isub - 1
+
+#ifdef SOLAR_RADVAL
+            ! default (no cloud) for TAUx variant
+            TAUTP(icol) = 0.
+            TAUHP(icol) = 0.
+            TAUMP(icol) = 0.
+            TAULP(icol) = 0.
+#endif
+
+            ! default (no cloud) for COTx variant
+            COTTP(icol) = MAPL_UNDEF
+            COTHP(icol) = MAPL_UNDEF
+            COTMP(icol) = MAPL_UNDEF
+            COTLP(icol) = MAPL_UNDEF
+
+            ! zero denom- and numerator accumulators
+            COTDTP(icol) = 0.; COTNTP(icol) = 0.
+            COTDHP(icol) = 0.; COTNHP(icol) = 0.
+            COTDMP(icol) = 0.; COTNMP(icol) = 0.
+            COTDLP(icol) = 0.; COTNLP(icol) = 0.
+#ifdef SOLAR_RADVAL
+            COTLDTP(icol) = 0.; COTLNTP(icol) = 0.; COTIDTP(icol) = 0.; COTINTP(icol) = 0.
+            COTLDHP(icol) = 0.; COTLNHP(icol) = 0.; COTIDHP(icol) = 0.; COTINHP(icol) = 0.
+            COTLDMP(icol) = 0.; COTLNMP(icol) = 0.; COTIDMP(icol) = 0.; COTINMP(icol) = 0.
+            COTLDLP(icol) = 0.; COTLNLP(icol) = 0.; COTIDLP(icol) = 0.; COTINLP(icol) = 0.
+            SSALDTP(icol) = 0.; SSALNTP(icol) = 0.; SSAIDTP(icol) = 0.; SSAINTP(icol) = 0.
+            SSALDHP(icol) = 0.; SSALNHP(icol) = 0.; SSAIDHP(icol) = 0.; SSAINHP(icol) = 0.
+            SSALDMP(icol) = 0.; SSALNMP(icol) = 0.; SSAIDMP(icol) = 0.; SSAINMP(icol) = 0.
+            SSALDLP(icol) = 0.; SSALNLP(icol) = 0.; SSAIDLP(icol) = 0.; SSAINLP(icol) = 0.
+            ASMLDTP(icol) = 0.; ASMLNTP(icol) = 0.; ASMIDTP(icol) = 0.; ASMINTP(icol) = 0.
+            ASMLDHP(icol) = 0.; ASMLNHP(icol) = 0.; ASMIDHP(icol) = 0.; ASMINHP(icol) = 0.
+            ASMLDMP(icol) = 0.; ASMLNMP(icol) = 0.; ASMIDMP(icol) = 0.; ASMINMP(icol) = 0.
+            ASMLDLP(icol) = 0.; ASMLNLP(icol) = 0.; ASMIDLP(icol) = 0.; ASMINLP(icol) = 0.
+#endif
+
+            ! can only be non-zero for potentially cloudy columns
+            if (any(CL(icol,:) > 0.)) then
+
+              ! accumulate over gpts/subcolumns
+              do ib = 1, nbnd
+                do igpt = band_lims_gpt(1,ib), band_lims_gpt(2,ib)
+
+                  ! band weights for photosynthetically active radiation (PAR)
+                  ! Bands 11-12 (0.345-0.625 um) plus half transition band 10 (0.625-0.778 um)
+                  if (ib >= 11 .and. ib <= 12) then
+                    wgt = 1.0
+                  else if (ib == 10) then
+                    wgt = 0.5
+                  else
+                    ! no contribution to PAR
+                    cycle
+                  end if
+
+                  ! TOA flux weighting
+                  ! (note: neither the adjustment of toa_flux to our tsi
+                  ! or for zenith angle are needed yet since this weighting
+                  ! is over gpoint and is normalized for EACH icol)
+                  wgt = wgt * toa_flux(isub,igpt)
+
+                  ! low pressure layer
+                  sltaulp = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt))
+                  sitaulp = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt))
+                  staulp = sltaulp + sitaulp
+                  if (staulp > 0.) then
+                    COTDLP(icol) = COTDLP(icol) + wgt
+                    COTNLP(icol) = COTNLP(icol) + wgt * staulp
+                  end if
+#ifdef SOLAR_RADVAL
+                  sltaussalp = 0.; sltaussaglp = 0.
+                  if (sltaulp > 0.) then
+                    select type(cloud_props_gpt_liq)
+                    class is (ty_optical_props_2str)
+                      sltaussalp = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt) * &
+                                       cloud_props_gpt_liq%ssa(isub,LCLDLM:LM,igpt))
+                      sltaussaglp = sum(cloud_props_gpt_liq%tau(isub,LCLDLM:LM,igpt) * &
+                                        cloud_props_gpt_liq%ssa(isub,LCLDLM:LM,igpt) * &
+                                        cloud_props_gpt_liq%g  (isub,LCLDLM:LM,igpt))
+                    end select
+                    COTLDLP(icol) = COTLDLP(icol) + wgt
+                    COTLNLP(icol) = COTLNLP(icol) + wgt * sltaulp
+                    SSALDLP(icol) = SSALDLP(icol) + wgt * sltaulp
+                    SSALNLP(icol) = SSALNLP(icol) + wgt * sltaussalp
+                    ASMLDLP(icol) = ASMLDLP(icol) + wgt * sltaussalp
+                    ASMLNLP(icol) = ASMLNLP(icol) + wgt * sltaussaglp
+                  end if
+                  sitaussalp = 0.; sitaussaglp = 0.
+                  if (sitaulp > 0.) then
+                    select type(cloud_props_gpt_ice)
+                    class is (ty_optical_props_2str)
+                      sitaussalp = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt) * &
+                                       cloud_props_gpt_ice%ssa(isub,LCLDLM:LM,igpt))
+                      sitaussaglp = sum(cloud_props_gpt_ice%tau(isub,LCLDLM:LM,igpt) * &
+                                        cloud_props_gpt_ice%ssa(isub,LCLDLM:LM,igpt) * &
+                                        cloud_props_gpt_ice%g  (isub,LCLDLM:LM,igpt))
+                    end select
+                    COTIDLP(icol) = COTIDLP(icol) + wgt
+                    COTINLP(icol) = COTINLP(icol) + wgt * sitaulp
+                    SSAIDLP(icol) = SSAIDLP(icol) + wgt * sitaulp
+                    SSAINLP(icol) = SSAINLP(icol) + wgt * sitaussalp
+                    ASMIDLP(icol) = ASMIDLP(icol) + wgt * sitaussalp
+                    ASMINLP(icol) = ASMINLP(icol) + wgt * sitaussaglp
+                  end if
+#endif
+
+                  ! mid pressure layer
+                  sltaump = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt))
+                  sitaump = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt))
+                  staump = sltaump + sitaump
+                  if (staump > 0.) then
+                    COTDMP(icol) = COTDMP(icol) + wgt
+                    COTNMP(icol) = COTNMP(icol) + wgt * staump
+                  end if
+#ifdef SOLAR_RADVAL
+                  sltaussamp = 0.; sltaussagmp = 0.
+                  if (sltaump > 0.) then
+                    select type(cloud_props_gpt_liq)
+                    class is (ty_optical_props_2str)
+                      sltaussamp = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                       cloud_props_gpt_liq%ssa(isub,LCLDMH:LCLDLM-1,igpt))
+                      sltaussagmp = sum(cloud_props_gpt_liq%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                        cloud_props_gpt_liq%ssa(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                        cloud_props_gpt_liq%g  (isub,LCLDMH:LCLDLM-1,igpt))
+                    end select
+                    COTLDMP(icol) = COTLDMP(icol) + wgt
+                    COTLNMP(icol) = COTLNMP(icol) + wgt * sltaump
+                    SSALDMP(icol) = SSALDMP(icol) + wgt * sltaump
+                    SSALNMP(icol) = SSALNMP(icol) + wgt * sltaussamp
+                    ASMLDMP(icol) = ASMLDMP(icol) + wgt * sltaussamp
+                    ASMLNMP(icol) = ASMLNMP(icol) + wgt * sltaussagmp
+                  end if
+                  sitaussamp = 0.; sitaussagmp = 0.
+                  if (sitaump > 0.) then
+                    select type(cloud_props_gpt_ice)
+                    class is (ty_optical_props_2str)
+                      sitaussamp = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                       cloud_props_gpt_ice%ssa(isub,LCLDMH:LCLDLM-1,igpt))
+                      sitaussagmp = sum(cloud_props_gpt_ice%tau(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                        cloud_props_gpt_ice%ssa(isub,LCLDMH:LCLDLM-1,igpt) * &
+                                        cloud_props_gpt_ice%g  (isub,LCLDMH:LCLDLM-1,igpt))
+                    end select
+                    COTIDMP(icol) = COTIDMP(icol) + wgt
+                    COTINMP(icol) = COTINMP(icol) + wgt * sitaump
+                    SSAIDMP(icol) = SSAIDMP(icol) + wgt * sitaump
+                    SSAINMP(icol) = SSAINMP(icol) + wgt * sitaussamp
+                    ASMIDMP(icol) = ASMIDMP(icol) + wgt * sitaussamp
+                    ASMINMP(icol) = ASMINMP(icol) + wgt * sitaussagmp
+                  end if
+#endif
+
+                  ! high pressure layer
+                  sltauhp = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt))
+                  sitauhp = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt))
+                  stauhp = sltauhp + sitauhp
+                  if (stauhp > 0.) then
+                    COTDHP(icol) = COTDHP(icol) + wgt
+                    COTNHP(icol) = COTNHP(icol) + wgt * stauhp
+                  end if
+#ifdef SOLAR_RADVAL
+                  sltaussahp = 0.; sltaussaghp = 0.
+                  if (sltauhp > 0.) then
+                    select type(cloud_props_gpt_liq)
+                    class is (ty_optical_props_2str)
+                      sltaussahp = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt) * &
+                                       cloud_props_gpt_liq%ssa(isub,1:LCLDMH-1,igpt))
+                      sltaussaghp = sum(cloud_props_gpt_liq%tau(isub,1:LCLDMH-1,igpt) * &
+                                        cloud_props_gpt_liq%ssa(isub,1:LCLDMH-1,igpt) * &
+                                        cloud_props_gpt_liq%g  (isub,1:LCLDMH-1,igpt))
+                    end select
+                    COTLDHP(icol) = COTLDHP(icol) + wgt
+                    COTLNHP(icol) = COTLNHP(icol) + wgt * sltauhp
+                    SSALDHP(icol) = SSALDHP(icol) + wgt * sltauhp
+                    SSALNHP(icol) = SSALNHP(icol) + wgt * sltaussahp
+                    ASMLDHP(icol) = ASMLDHP(icol) + wgt * sltaussahp
+                    ASMLNHP(icol) = ASMLNHP(icol) + wgt * sltaussaghp
+                  end if
+                  sitaussahp = 0.; sitaussaghp = 0.
+                  if (sitauhp > 0.) then
+                    select type(cloud_props_gpt_ice)
+                    class is (ty_optical_props_2str)
+                      sitaussahp = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt) * &
+                                       cloud_props_gpt_ice%ssa(isub,1:LCLDMH-1,igpt))
+                      sitaussaghp = sum(cloud_props_gpt_ice%tau(isub,1:LCLDMH-1,igpt) * &
+                                        cloud_props_gpt_ice%ssa(isub,1:LCLDMH-1,igpt) * &
+                                        cloud_props_gpt_ice%g  (isub,1:LCLDMH-1,igpt))
+                    end select
+                    COTIDHP(icol) = COTIDHP(icol) + wgt
+                    COTINHP(icol) = COTINHP(icol) + wgt * sitauhp
+                    SSAIDHP(icol) = SSAIDHP(icol) + wgt * sitauhp
+                    SSAINHP(icol) = SSAINHP(icol) + wgt * sitaussahp
+                    ASMIDHP(icol) = ASMIDHP(icol) + wgt * sitaussahp
+                    ASMINHP(icol) = ASMINHP(icol) + wgt * sitaussaghp
+                  end if
+#endif
+
+                  ! whole subcolumn
+                  sltautp = sltaulp + sltaump + sltauhp
+                  sitautp = sitaulp + sitaump + sitauhp
+                  stautp = staulp + staump + stauhp
+                  if (stautp > 0.) then
+                    COTDTP(icol) = COTDTP(icol) + wgt
+                    COTNTP(icol) = COTNTP(icol) + wgt * stautp
+                  end if
+#ifdef SOLAR_RADVAL
+                  sltaussatp = sltaussalp + sltaussamp + sltaussahp
+                  sltaussagtp = sltaussaglp + sltaussagmp + sltaussaghp
+                  if (sltautp > 0.) then
+                    COTLDTP(icol) = COTLDTP(icol) + wgt
+                    COTLNTP(icol) = COTLNTP(icol) + wgt * sltautp
+                    SSALDTP(icol) = SSALDTP(icol) + wgt * sltautp
+                    SSALNTP(icol) = SSALNTP(icol) + wgt * sltaussatp
+                    ASMLDTP(icol) = ASMLDTP(icol) + wgt * sltaussatp
+                    ASMLNTP(icol) = ASMLNTP(icol) + wgt * sltaussagtp
+                  end if
+                  sitaussatp = sitaussalp + sitaussamp + sitaussahp
+                  sitaussagtp = sitaussaglp + sitaussagmp + sitaussaghp
+                  if (sitautp > 0.) then
+                    COTIDTP(icol) = COTIDTP(icol) + wgt
+                    COTINTP(icol) = COTINTP(icol) + wgt * sitautp
+                    SSAIDTP(icol) = SSAIDTP(icol) + wgt * sitautp
+                    SSAINTP(icol) = SSAINTP(icol) + wgt * sitaussatp
+                    ASMIDTP(icol) = ASMIDTP(icol) + wgt * sitaussatp
+                    ASMINTP(icol) = ASMINTP(icol) + wgt * sitaussagtp
+                  end if
+#endif
+
+                end do ! igpt
+              end do ! ib
+
+              ! normalize
+              ! Note: TAUx defaults zero, COTx defaults MAPL_UNDEF
+              if (COTDTP(icol) > 0. .and. COTNTP(icol) > 0.) then
+                COTTP(icol) = COTNTP(icol) / COTDTP(icol)
+#ifdef SOLAR_RADVAL
+                TAUTP(icol) = COTTP(icol)
+#endif
+              end if
+
+              if (COTDHP(icol) > 0. .and. COTNHP(icol) > 0.) then
+                COTHP(icol) = COTNHP(icol) / COTDHP(icol)
+#ifdef SOLAR_RADVAL
+                TAUHP(icol) = COTHP(icol)
+#endif
+              end if
+
+              if (COTDMP(icol) > 0. .and. COTNMP(icol) > 0.) then
+                COTMP(icol) = COTNMP(icol) / COTDMP(icol)
+#ifdef SOLAR_RADVAL
+                TAUMP(icol) = COTMP(icol)
+#endif
+              end if
+
+              if (COTDLP(icol) > 0. .and. COTNLP(icol) > 0.) then
+                COTLP(icol) = COTNLP(icol) / COTDLP(icol)
+#ifdef SOLAR_RADVAL
+                TAULP(icol) = COTLP(icol)
+#endif
+              end if
+
+            end if  ! potentially cloudy column
+          end do  ! isub
+      end if  ! include_aerosols
+
+      call MAPL_TimerOff(MAPL,"--RRTMGP_SPRLYR_DIAGS",__RC__)
+
+      RETURN_(ESMF_SUCCESS)
+
+    end subroutine compute_sprlyr_diags_predelta
 #undef TEST_
 
 

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -5293,47 +5293,8 @@ contains
           optical_props, toa_flux, MAPL, __RC__)
 
         ! get block of aerosol optical props
-        if (need_aer_optical_props) then
-          select type (aer_props)
-            class is (ty_optical_props_2str)
-
-              ! load un-normalized optical properties from aerosol system
-              aer_props%tau = real(TAUA(colS:colE,:,:),kind=wp)
-              aer_props%ssa = real(SSAA(colS:colE,:,:),kind=wp)
-              aer_props%g   = real(ASYA(colS:colE,:,:),kind=wp)
-
-              ! renormalize
-              where (aer_props%tau > 0._wp .and. aer_props%ssa > 0._wp)
-                aer_props%g   = aer_props%g   / aer_props%ssa
-                aer_props%ssa = aer_props%ssa / aer_props%tau
-              elsewhere
-                aer_props%tau = 0._wp
-                aer_props%ssa = 0._wp
-                aer_props%g   = 0._wp
-              end where
-
-              ! Because RRTMGP is (currently) compiled at R8,
-              ! _wp is R8. Apparently with aggressive compiler
-              ! flags using Intel, it's possible for, say,
-              ! aer_props%ssa to become slightly greater than one
-              ! in the above renormalization. So, we add clamps
-              ! to the values based on the restrictions see in
-              ! RRTMGP/rte-frontend/mo_optical_props.F90
-              !
-              ! In testing, the values seen were like 1.00000011905028
-              ! so just slightly above one.
-
-              ! tau must be greater than 0.0
-              aer_props%tau = max(aer_props%tau, 0._wp)
-              ! ssa must be between 0.0 and 1.0
-              aer_props%ssa = max(min(aer_props%ssa, 1._wp), 0._wp)
-              ! g must be between -1.0 and 1.0
-              aer_props%g   = max(min(aer_props%g,   1._wp),-1._wp)
-
-            class default
-              TEST_('aerosol optical properties hardwired 2-stream for now')
-          end select
-        end if
+        call compute_aer_optics(colS, colE, need_aer_optical_props, &
+          taua, ssaa, asya, aer_props, __RC__)
 
         call MAPL_TimerOn(MAPL,"--RRTMGP_CLOUD_OPTICS",__RC__)
 
@@ -6892,6 +6853,75 @@ contains
       RETURN_(ESMF_SUCCESS)
 
     end subroutine compute_gas_optics
+#undef TEST_
+
+    ! ---------------------------------------------------------------------------
+    ! Load and normalize aerosol optical properties for one block of columns.
+    ! No thread-private locals beyond scalars; aer_props is intent(inout).
+    ! ---------------------------------------------------------------------------
+#define TEST_(A) error_msg = A; if (trim(error_msg)/="") then; _FAIL("RRTMGP Error: "//trim(error_msg)); endif
+    subroutine compute_aer_optics(colS, colE, need_aer_optical_props, &
+        taua, ssaa, asya, aer_props, RC)
+
+      use mo_optical_props, only: ty_optical_props_arry, ty_optical_props_2str
+      use mo_rte_kind,      only: wp
+
+      integer,                        intent(in)    :: colS, colE
+      logical,                        intent(in)    :: need_aer_optical_props
+      real,             dimension(:,:,:), intent(in)    :: taua, ssaa, asya
+      class(ty_optical_props_arry),   intent(inout) :: aer_props
+      integer, optional,              intent(out)   :: RC
+
+      character(len=ESMF_MAXSTR) :: error_msg
+      integer                    :: STATUS
+
+      if (.not. need_aer_optical_props) then
+        RETURN_(ESMF_SUCCESS)
+      end if
+
+      select type (aer_props)
+        class is (ty_optical_props_2str)
+
+          ! load un-normalized optical properties from aerosol system
+          aer_props%tau = real(taua(colS:colE,:,:),kind=wp)
+          aer_props%ssa = real(ssaa(colS:colE,:,:),kind=wp)
+          aer_props%g   = real(asya(colS:colE,:,:),kind=wp)
+
+          ! renormalize
+          where (aer_props%tau > 0._wp .and. aer_props%ssa > 0._wp)
+            aer_props%g   = aer_props%g   / aer_props%ssa
+            aer_props%ssa = aer_props%ssa / aer_props%tau
+          elsewhere
+            aer_props%tau = 0._wp
+            aer_props%ssa = 0._wp
+            aer_props%g   = 0._wp
+          end where
+
+          ! Because RRTMGP is (currently) compiled at R8,
+          ! _wp is R8. Apparently with aggressive compiler
+          ! flags using Intel, it's possible for, say,
+          ! aer_props%ssa to become slightly greater than one
+          ! in the above renormalization. So, we add clamps
+          ! to the values based on the restrictions see in
+          ! RRTMGP/rte-frontend/mo_optical_props.F90
+          !
+          ! In testing, the values seen were like 1.00000011905028
+          ! so just slightly above one.
+
+          ! tau must be greater than 0.0
+          aer_props%tau = max(aer_props%tau, 0._wp)
+          ! ssa must be between 0.0 and 1.0
+          aer_props%ssa = max(min(aer_props%ssa, 1._wp), 0._wp)
+          ! g must be between -1.0 and 1.0
+          aer_props%g   = max(min(aer_props%g,   1._wp),-1._wp)
+
+        class default
+          TEST_('aerosol optical properties hardwired 2-stream for now')
+      end select
+
+      RETURN_(ESMF_SUCCESS)
+
+    end subroutine compute_aer_optics
 #undef TEST_
 
 

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -5043,13 +5043,9 @@ contains
       ! For nstr, must also specify the number of phase function moments (nmom) below.
       ! =====================================================================================
 
-      ! instantiate optical_props with desired streams
-      allocate(ty_optical_props_2str::optical_props,__STAT__)  ! <-- choose 2-stream SW
-
-      ! initialize spectral discretiz'n and gpt mapping of optical_props
-      TEST_(optical_props%init(k_dist))
-
-      ! Used only if nstr (and then must be >= 2)
+      ! instantiate and initialize optical_props, cloud_props_bnd/gpt, and aer_props
+      ! inside PROCESS_RRTMGP_BLOCK so each OpenMP thread gets private copies.
+      ! nmom is only used if nstr (and then must be >= 2)
       nmom = 2
 
       ! get cloud optical properties (band-only)
@@ -5090,31 +5086,6 @@ contains
         MAPL, rrtmgp_use_rrtmg_iceflg3_like_forwice, &
         LABEL='RRTMGP_USE_RRTMG_ICEFLG3_LIKE_FORWICE:', &
         DEFAULT=.TRUE., __RC__)
-
-      ! cloud optics file is currently two-stream
-      ! increment() will handle appropriate stream conversions
-      allocate(ty_optical_props_2str::cloud_props_bnd_liq,__STAT__)
-      allocate(ty_optical_props_2str::cloud_props_bnd_ice,__STAT__)
-
-      ! band-only initialization for pre-mcICA cloud optical properties
-      TEST_(cloud_props_bnd_liq%init(k_dist%get_band_lims_wavenumber()))
-      TEST_(cloud_props_bnd_ice%init(k_dist%get_band_lims_wavenumber()))
-
-      ! g-point version for McICA sampled cloud optical properties
-      select type (cloud_props_bnd_liq)
-        class is (ty_optical_props_2str)
-          allocate(ty_optical_props_2str::cloud_props_gpt_liq,__STAT__)
-        class default
-          TEST_('cloud optical properties (liq) hardwired 2-stream for now')
-      end select
-      select type (cloud_props_bnd_ice)
-        class is (ty_optical_props_2str)
-          allocate(ty_optical_props_2str::cloud_props_gpt_ice,__STAT__)
-        class default
-          TEST_('cloud optical properties (ice) hardwired 2-stream for now')
-      end select
-      TEST_(cloud_props_gpt_liq%init(k_dist))
-      TEST_(cloud_props_gpt_ice%init(k_dist))
 
       ! read desired cloud overlap type
       call MAPL_GetResource( &
@@ -5202,13 +5173,7 @@ contains
 
       ! set up aerosol optical properties
       need_aer_optical_props = (include_aerosols .and. implements_aerosol_optics)
-      if (need_aer_optical_props) then
-        ! aerosol optics system is currently two-stream
-        ! increment() will handle appropriate stream conversions
-        allocate(ty_optical_props_2str::aer_props,__STAT__)
-        ! band-only initialization
-        TEST_(aer_props%init(k_dist%get_band_lims_wavenumber()))
-      end if
+      ! aer_props is allocated and initialized inside PROCESS_RRTMGP_BLOCK
 
       !-------------------------------------------------------!
       ! Loop over blocks of blockSize columns                 !
@@ -5228,80 +5193,20 @@ contains
       ! loop over all blocks
       do b = 1,nBlocks
 
-        ! compute block column range; the final block may be partial
-        ncols_block = min(rrtmgp_blockSize, ncol - (b-1)*rrtmgp_blockSize)
-        colS = (b-1) * rrtmgp_blockSize + 1
-        colE = colS + ncols_block - 1
-
-        ! allocate per-block arrays sized to this block's column count
-        ! Note: urand, urand_aux, urand_cond, urand_cond_aux, alpha, rcorr, zcw,
-        ! seeds, cld_mask are now local to compute_cloud_optics_mcica.
-        ! cld_mask is intent(out) and is allocated inside that subroutine.
-
-        allocate(toa_flux(ncols_block,ngpt),    __STAT__)
-        allocate(forwliq(ncols_block,LM,ngpt),  __STAT__)
-        allocate(forwice(ncols_block,LM,ngpt),  __STAT__)
-        if (include_aerosols) &
-          allocate(ClearCounts(4,ncols_block),  __STAT__)
-
-        ! ty_optical_props routines have an internal deallocation
-        select type (cloud_props_bnd_liq)
-          class is (ty_optical_props_2str)
-            TEST_(cloud_props_bnd_liq%alloc_2str(ncols_block,LM))
-        end select
-        select type (cloud_props_bnd_ice)
-          class is (ty_optical_props_2str)
-            TEST_(cloud_props_bnd_ice%alloc_2str(ncols_block,LM))
-        end select
-        select type (cloud_props_gpt_liq)
-          class is (ty_optical_props_2str)
-            TEST_(cloud_props_gpt_liq%alloc_2str(ncols_block,LM))
-        end select
-        select type (cloud_props_gpt_ice)
-          class is (ty_optical_props_2str)
-            TEST_(cloud_props_gpt_ice%alloc_2str(ncols_block,LM))
-        end select
-        if (need_aer_optical_props) then
-          select type (aer_props)
-            class is (ty_optical_props_2str)
-              TEST_(aer_props%alloc_2str(ncols_block,LM))
-          end select
-        end if
-        select type (optical_props)
-          class is (ty_optical_props_1scl)
-            TEST_(optical_props%alloc_1scl(ncols_block,LM))
-          class is (ty_optical_props_2str)
-            TEST_(optical_props%alloc_2str(ncols_block,LM))
-          class is (ty_optical_props_nstr)
-            TEST_(optical_props%alloc_nstr(nmom,ncols_block,LM))
-        end select
-        call compute_gas_optics(colS, colE, ncols_block, LM, &
-          gas_concs, k_dist, p_lay, p_lev, t_lay, &
-          optical_props, toa_flux, MAPL, __RC__)
-
-        ! get block of aerosol optical props
-        call compute_aer_optics(colS, colE, need_aer_optical_props, &
-          taua, ssaa, asya, aer_props, __RC__)
-
-        call compute_cloud_optics_mcica( &
-          colS, colE, ncols_block, LM, ngpt, &
-          gen_mro, cond_inhomo, cloud_overlap_type, cwp_fac, IM_World, &
-          seeds(2), &
-          QQ3, RR3, dp_wp, dummy_wp, CL, dzmid, adl, rdl, Ig1D, Jg1D, &
-          cloud_optics, &
-          cloud_props_bnd_liq, cloud_props_bnd_ice, &
-          cloud_props_gpt_liq, cloud_props_gpt_ice, &
-          cld_mask, &
-          MAPL, __RC__)
-
-        ! REFRESH super-layer diagnostics (before delta-scaling TAUs).
-        ! ** Calculated from subcolumn ensemble, so stochastic **
-        ! -------------------------------------------------------
-        call compute_sprlyr_diags_predelta( &
-          colS, ncols_block, LM, ngpt, nbnd, LCLDLM, LCLDMH, &
-          include_aerosols, &
-          cld_mask, ClearCounts, CL, toa_flux, band_lims_gpt, &
-          cloud_props_gpt_liq, cloud_props_gpt_ice, &
+        call PROCESS_RRTMGP_BLOCK( &
+          b, ncol, rrtmgp_blockSize, LM, ngpt, nbnd, nmom, &
+          LCLDLM, LCLDMH, include_aerosols, gen_mro, cond_inhomo, &
+          cloud_overlap_type, IM_World, seeds(2), &
+          need_aer_optical_props, top_at_1, &
+          rrtmgp_delta_scale, rrtmgp_use_rrtmg_iceflg3_like_forwice, &
+          cwp_fac, &
+          gas_concs, k_dist, cloud_optics, &
+          p_lay, p_lev, t_lay, QQ3, RR3, dp_wp, dummy_wp, &
+          CL, dzmid, adl, rdl, Ig1D, Jg1D, band_lims_gpt, &
+          tsi, mu0, sfc_alb_dir, sfc_alb_dif, taua, ssaa, asya, &
+          flux_up_clrsky, flux_net_clrsky, &
+          flux_up_allsky, flux_net_allsky, &
+          bnd_flux_dn_allsky, bnd_flux_dir_allsky, bnd_flux_net_allsky, &
           CLDTS, CLDHS, CLDMS, CLDLS, &
           COTTP, COTHP, COTMP, COTLP, &
           COTDTP, COTDHP, COTDMP, COTDLP, &
@@ -5320,29 +5225,6 @@ contains
           ASMLNTP, ASMLNHP, ASMLNMP, ASMLNLP, &
           ASMIDTP, ASMIDHP, ASMIDMP, ASMIDLP, &
           ASMINTP, ASMINHP, ASMINMP, ASMINLP, &
-#endif
-          MAPL, __RC__)
-
-
-        ! delta-scaling of cloud optical properties (accounts for forward scattering)
-        call compute_delta_scale( &
-          colS, ncols_block, LM, ngpt, nbnd, &
-          rrtmgp_delta_scale, rrtmgp_use_rrtmg_iceflg3_like_forwice, &
-          CL, RR3, band_lims_gpt, &
-          cloud_optics, cloud_props_gpt_liq, cloud_props_gpt_ice, &
-          forwliq, forwice, &
-          MAPL, __RC__)
-
-#ifdef SOLAR_RADVAL
-        ! REFRESH super-layer diagnostics (after delta-scaling TAUs).
-        ! ** Calculated from subcolumn ensemble, so stochastic **
-        ! -------------------------------------------------------
-        call compute_sprlyr_diags_postdelta( &
-          colS, ncols_block, LM, ngpt, nbnd, LCLDLM, LCLDMH, &
-          include_aerosols, &
-          CL, toa_flux, band_lims_gpt, &
-          forwliq, forwice, &
-          cloud_props_gpt_liq, cloud_props_gpt_ice, &
           CDSDTP, CDSDHP, CDSDMP, CDSDLP, &
           CDSNTP, CDSNHP, CDSNMP, CDSNLP, &
           CDSLDTP, CDSLDHP, CDSLDMP, CDSLDLP, &
@@ -5361,28 +5243,8 @@ contains
           FORLNTP, FORLNHP, FORLNMP, FORLNLP, &
           FORIDTP, FORIDHP, FORIDMP, FORIDLP, &
           FORINTP, FORINHP, FORINMP, FORINLP, &
-          MAPL, __RC__)
 #endif
-
-        call compute_rte_sw( &
-          colS, colE, ngpt, &
-          tsi, toa_flux, need_aer_optical_props, aer_props, optical_props, &
-          top_at_1, mu0, sfc_alb_dir, sfc_alb_dif, &
-          fluxes_clrsky, flux_up_clrsky, flux_net_clrsky, &
-          fluxes_allsky, flux_up_allsky, flux_net_allsky, &
-          bnd_flux_dn_allsky, bnd_flux_dir_allsky, bnd_flux_net_allsky, &
-          cloud_props_gpt_liq, cloud_props_gpt_ice, &
           MAPL, __RC__)
-
-        ! deallocate per-block arrays
-        ! Note: urand*, alpha, rcorr, zcw are now local to compute_cloud_optics_mcica.
-        ! cld_mask is intent(out) from that subroutine; deallocate it here after use.
-        deallocate(toa_flux,      __STAT__)
-        deallocate(cld_mask,      __STAT__)
-        deallocate(forwliq,       __STAT__)
-        deallocate(forwice,       __STAT__)
-        if (include_aerosols) &
-          deallocate(ClearCounts, __STAT__)
 
       end do ! loop over blocks
 
@@ -5482,12 +5344,8 @@ contains
         endif
       end if
       call cloud_optics%finalize()
-      call cloud_props_gpt_liq%finalize()
-      call cloud_props_gpt_ice%finalize()
-      call cloud_props_bnd_liq%finalize()
-      call cloud_props_bnd_ice%finalize()
-      if (need_aer_optical_props) call aer_props%finalize()
-      call optical_props%finalize()
+      ! cloud_props_gpt/bnd, aer_props, optical_props are local to PROCESS_RRTMGP_BLOCK
+      ! and are finalized automatically when that subroutine returns.
 
       call MAPL_TimerOff(MAPL,"--RRTMGP_POST",__RC__)
 
@@ -7323,6 +7181,341 @@ contains
 
       RETURN
     end subroutine compute_rte_sw
+#undef TEST_
+
+#define TEST_(A) error_msg = A; if (trim(error_msg)/="") then; _FAIL("RRTMGP Error: "//trim(error_msg)); endif
+    subroutine PROCESS_RRTMGP_BLOCK( &
+        b, ncol, rrtmgp_blockSize, LM, ngpt, nbnd, nmom, &
+        LCLDLM, LCLDMH, include_aerosols, gen_mro, cond_inhomo, &
+        cloud_overlap_type, IM_World, seeds_time_key, &
+        need_aer_optical_props, top_at_1, &
+        rrtmgp_delta_scale, rrtmgp_use_rrtmg_iceflg3_like_forwice, &
+        cwp_fac_arg, &
+        gas_concs, k_dist, cloud_optics, &
+        p_lay, p_lev, t_lay, QQ3, RR3, dp_wp, dummy_wp, &
+        CL, dzmid, adl, rdl, Ig1D, Jg1D, band_lims_gpt, &
+        tsi, mu0, sfc_alb_dir, sfc_alb_dif, taua, ssaa, asya, &
+        flux_up_clrsky, flux_net_clrsky, &
+        flux_up_allsky, flux_net_allsky, &
+        bnd_flux_dn_allsky, bnd_flux_dir_allsky, bnd_flux_net_allsky, &
+        CLDTS, CLDHS, CLDMS, CLDLS, &
+        COTTP, COTHP, COTMP, COTLP, &
+        COTDTP, COTDHP, COTDMP, COTDLP, &
+        COTNTP, COTNHP, COTNMP, COTNLP, &
+#ifdef SOLAR_RADVAL
+        TAUTP, TAUHP, TAUMP, TAULP, &
+        COTLDTP, COTLDHP, COTLDMP, COTLDLP, &
+        COTLNTP, COTLNHP, COTLNMP, COTLNLP, &
+        COTIDTP, COTIDHP, COTIDMP, COTIDLP, &
+        COTINTP, COTINHP, COTINMP, COTINLP, &
+        SSALDTP, SSALDHP, SSALDMP, SSALDLP, &
+        SSALNTP, SSALNHP, SSALNMP, SSALNLP, &
+        SSAIDTP, SSAIDHP, SSAIDMP, SSAIDLP, &
+        SSAINTP, SSAINHP, SSAINMP, SSAINLP, &
+        ASMLDTP, ASMLDHP, ASMLDMP, ASMLDLP, &
+        ASMLNTP, ASMLNHP, ASMLNMP, ASMLNLP, &
+        ASMIDTP, ASMIDHP, ASMIDMP, ASMIDLP, &
+        ASMINTP, ASMINHP, ASMINMP, ASMINLP, &
+        CDSDTP, CDSDHP, CDSDMP, CDSDLP, &
+        CDSNTP, CDSNHP, CDSNMP, CDSNLP, &
+        CDSLDTP, CDSLDHP, CDSLDMP, CDSLDLP, &
+        CDSLNTP, CDSLNHP, CDSLNMP, CDSLNLP, &
+        CDSIDTP, CDSIDHP, CDSIDMP, CDSIDLP, &
+        CDSINTP, CDSINHP, CDSINMP, CDSINLP, &
+        SDSLDTP, SDSLDHP, SDSLDMP, SDSLDLP, &
+        SDSLNTP, SDSLNHP, SDSLNMP, SDSLNLP, &
+        SDSIDTP, SDSIDHP, SDSIDMP, SDSIDLP, &
+        SDSINTP, SDSINHP, SDSINMP, SDSINLP, &
+        ADSLDTP, ADSLDHP, ADSLDMP, ADSLDLP, &
+        ADSLNTP, ADSLNHP, ADSLNMP, ADSLNLP, &
+        ADSIDTP, ADSIDHP, ADSIDMP, ADSIDLP, &
+        ADSINTP, ADSINHP, ADSINMP, ADSINLP, &
+        FORLDTP, FORLDHP, FORLDMP, FORLDLP, &
+        FORLNTP, FORLNHP, FORLNMP, FORLNLP, &
+        FORIDTP, FORIDHP, FORIDMP, FORIDLP, &
+        FORINTP, FORINHP, FORINMP, FORINLP, &
+#endif
+        MAPL, RC)
+
+      use mo_optical_props,         only: ty_optical_props_arry, ty_optical_props_1scl, &
+                                          ty_optical_props_2str, ty_optical_props_nstr
+      use mo_rte_kind,              only: wp
+      use mo_gas_optics_rrtmgp,     only: ty_gas_optics_rrtmgp
+      use mo_gas_concentrations,    only: ty_gas_concs
+      use mo_cloud_optics_rrtmgp,   only: ty_cloud_optics_rrtmgp
+      use mo_fluxes_byband,         only: ty_fluxes_byband
+
+      integer,                        intent(in)    :: b, ncol, rrtmgp_blockSize
+      integer,                        intent(in)    :: LM, ngpt, nbnd, nmom
+      integer,                        intent(in)    :: LCLDLM, LCLDMH
+      logical,                        intent(in)    :: include_aerosols
+      logical,                        intent(in)    :: gen_mro, cond_inhomo
+      character(len=*),               intent(in)    :: cloud_overlap_type
+      integer,                        intent(in)    :: IM_World
+      integer,                        intent(in)    :: seeds_time_key
+      logical,                        intent(in)    :: need_aer_optical_props
+      logical,                        intent(in)    :: top_at_1
+      logical,                        intent(in)    :: rrtmgp_delta_scale
+      logical,                        intent(in)    :: rrtmgp_use_rrtmg_iceflg3_like_forwice
+      real(wp),                       intent(in)    :: cwp_fac_arg
+      type(ty_gas_concs),             intent(in)    :: gas_concs
+      type(ty_gas_optics_rrtmgp),     intent(in)    :: k_dist
+      type(ty_cloud_optics_rrtmgp),   intent(inout) :: cloud_optics
+      real(wp),                       intent(in)    :: p_lay(:,:), p_lev(:,:), t_lay(:,:)
+      real,                           intent(in)    :: QQ3(:,:,:), RR3(:,:,:)
+      real(wp),                       intent(in)    :: dp_wp(:,:), dummy_wp(:,:)
+      real,                           intent(in)    :: CL(:,:)
+      real(wp),                       intent(in)    :: dzmid(:,:)
+      real,                           intent(in)    :: adl(:), rdl(:)
+      real,                           intent(in)    :: Ig1D(:), Jg1D(:)
+      integer,                        intent(in)    :: band_lims_gpt(:,:)
+      real(wp),                       intent(in)    :: tsi(:), mu0(:)
+      real(wp),                       intent(in)    :: sfc_alb_dir(:,:), sfc_alb_dif(:,:)
+      real,                           intent(in)    :: taua(:,:,:), ssaa(:,:,:), asya(:,:,:)
+      real(wp),          target,      intent(inout) :: flux_up_clrsky(:,:), flux_net_clrsky(:,:)
+      real(wp),          target,      intent(inout) :: flux_up_allsky(:,:), flux_net_allsky(:,:)
+      real(wp),          target,      intent(inout) :: bnd_flux_dn_allsky(:,:,:)
+      real(wp),          target,      intent(inout) :: bnd_flux_dir_allsky(:,:,:)
+      real(wp),          target,      intent(inout) :: bnd_flux_net_allsky(:,:,:)
+      real,                           intent(inout) :: CLDTS(:), CLDHS(:), CLDMS(:), CLDLS(:)
+      real,                           intent(inout) :: COTTP(:), COTHP(:), COTMP(:), COTLP(:)
+      real,                           intent(inout) :: COTDTP(:), COTDHP(:), COTDMP(:), COTDLP(:)
+      real,                           intent(inout) :: COTNTP(:), COTNHP(:), COTNMP(:), COTNLP(:)
+#ifdef SOLAR_RADVAL
+      real,                           intent(inout) :: TAUTP(:), TAUHP(:), TAUMP(:), TAULP(:)
+      real,                           intent(inout) :: COTLDTP(:), COTLDHP(:), COTLDMP(:), COTLDLP(:)
+      real,                           intent(inout) :: COTLNTP(:), COTLNHP(:), COTLNMP(:), COTLNLP(:)
+      real,                           intent(inout) :: COTIDTP(:), COTIDHP(:), COTIDMP(:), COTIDLP(:)
+      real,                           intent(inout) :: COTINTP(:), COTINHP(:), COTINMP(:), COTINLP(:)
+      real,                           intent(inout) :: SSALDTP(:), SSALDHP(:), SSALDMP(:), SSALDLP(:)
+      real,                           intent(inout) :: SSALNTP(:), SSALNHP(:), SSALNMP(:), SSALNLP(:)
+      real,                           intent(inout) :: SSAIDTP(:), SSAIDHP(:), SSAIDMP(:), SSAIDLP(:)
+      real,                           intent(inout) :: SSAINTP(:), SSAINHP(:), SSAINMP(:), SSAINLP(:)
+      real,                           intent(inout) :: ASMLDTP(:), ASMLDHP(:), ASMLDMP(:), ASMLDLP(:)
+      real,                           intent(inout) :: ASMLNTP(:), ASMLNHP(:), ASMLNMP(:), ASMLNLP(:)
+      real,                           intent(inout) :: ASMIDTP(:), ASMIDHP(:), ASMIDMP(:), ASMIDLP(:)
+      real,                           intent(inout) :: ASMINTP(:), ASMINHP(:), ASMINMP(:), ASMINLP(:)
+      real,                           intent(inout) :: CDSDTP(:), CDSDHP(:), CDSDMP(:), CDSDLP(:)
+      real,                           intent(inout) :: CDSNTP(:), CDSNHP(:), CDSNMP(:), CDSNLP(:)
+      real,                           intent(inout) :: CDSLDTP(:), CDSLDHP(:), CDSLDMP(:), CDSLDLP(:)
+      real,                           intent(inout) :: CDSLNTP(:), CDSLNHP(:), CDSLNMP(:), CDSLNLP(:)
+      real,                           intent(inout) :: CDSIDTP(:), CDSIDHP(:), CDSIDMP(:), CDSIDLP(:)
+      real,                           intent(inout) :: CDSINTP(:), CDSINHP(:), CDSINMP(:), CDSINLP(:)
+      real,                           intent(inout) :: SDSLDTP(:), SDSLDHP(:), SDSLDMP(:), SDSLDLP(:)
+      real,                           intent(inout) :: SDSLNTP(:), SDSLNHP(:), SDSLNMP(:), SDSLNLP(:)
+      real,                           intent(inout) :: SDSIDTP(:), SDSIDHP(:), SDSIDMP(:), SDSIDLP(:)
+      real,                           intent(inout) :: SDSINTP(:), SDSINHP(:), SDSINMP(:), SDSINLP(:)
+      real,                           intent(inout) :: ADSLDTP(:), ADSLDHP(:), ADSLDMP(:), ADSLDLP(:)
+      real,                           intent(inout) :: ADSLNTP(:), ADSLNHP(:), ADSLNMP(:), ADSLNLP(:)
+      real,                           intent(inout) :: ADSIDTP(:), ADSIDHP(:), ADSIDMP(:), ADSIDLP(:)
+      real,                           intent(inout) :: ADSINTP(:), ADSINHP(:), ADSINMP(:), ADSINLP(:)
+      real,                           intent(inout) :: FORLDTP(:), FORLDHP(:), FORLDMP(:), FORLDLP(:)
+      real,                           intent(inout) :: FORLNTP(:), FORLNHP(:), FORLNMP(:), FORLNLP(:)
+      real,                           intent(inout) :: FORIDTP(:), FORIDHP(:), FORIDMP(:), FORIDLP(:)
+      real,                           intent(inout) :: FORINTP(:), FORINHP(:), FORINMP(:), FORINLP(:)
+#endif
+      type(MAPL_MetaComp),            intent(inout) :: MAPL
+      integer,            optional,   intent(out)   :: RC
+
+      ! per-block private local variables
+      integer                                        :: colS, colE, ncols_block
+      integer,               allocatable             :: ClearCounts(:,:)
+      logical,               allocatable             :: cld_mask(:,:,:)
+      real(wp),              allocatable             :: toa_flux(:,:)
+      real(wp),              allocatable             :: forwliq(:,:,:), forwice(:,:,:)
+      class(ty_optical_props_arry), allocatable      :: optical_props
+      class(ty_optical_props_arry), allocatable      :: cloud_props_bnd_liq, cloud_props_bnd_ice
+      class(ty_optical_props_arry), allocatable      :: cloud_props_gpt_liq, cloud_props_gpt_ice
+      class(ty_optical_props_arry), allocatable      :: aer_props
+      type(ty_fluxes_byband)                         :: fluxes_clrsky, fluxes_allsky
+
+      character(len=512) :: error_msg
+      integer            :: STATUS
+
+      ! compute block column range; the final block may be partial
+      ncols_block = min(rrtmgp_blockSize, ncol - (b-1)*rrtmgp_blockSize)
+      colS = (b-1) * rrtmgp_blockSize + 1
+      colE = colS + ncols_block - 1
+
+      ! allocate per-block arrays
+      allocate(toa_flux(ncols_block,ngpt),    __STAT__)
+      allocate(forwliq(ncols_block,LM,ngpt),  __STAT__)
+      allocate(forwice(ncols_block,LM,ngpt),  __STAT__)
+      if (include_aerosols) &
+        allocate(ClearCounts(4,ncols_block),  __STAT__)
+
+      ! instantiate optical_props with desired streams
+      allocate(ty_optical_props_2str::optical_props,__STAT__)  ! <-- choose 2-stream SW
+      TEST_(optical_props%init(k_dist))
+
+      ! cloud optics: band-space and g-point allocatables (thread-private)
+      allocate(ty_optical_props_2str::cloud_props_bnd_liq,__STAT__)
+      allocate(ty_optical_props_2str::cloud_props_bnd_ice,__STAT__)
+      TEST_(cloud_props_bnd_liq%init(k_dist%get_band_lims_wavenumber()))
+      TEST_(cloud_props_bnd_ice%init(k_dist%get_band_lims_wavenumber()))
+
+      select type (cloud_props_bnd_liq)
+        class is (ty_optical_props_2str)
+          allocate(ty_optical_props_2str::cloud_props_gpt_liq,__STAT__)
+        class default
+          TEST_('cloud optical properties (liq) hardwired 2-stream for now')
+      end select
+      select type (cloud_props_bnd_ice)
+        class is (ty_optical_props_2str)
+          allocate(ty_optical_props_2str::cloud_props_gpt_ice,__STAT__)
+        class default
+          TEST_('cloud optical properties (ice) hardwired 2-stream for now')
+      end select
+      TEST_(cloud_props_gpt_liq%init(k_dist))
+      TEST_(cloud_props_gpt_ice%init(k_dist))
+
+      ! aerosol optical properties (thread-private)
+      if (need_aer_optical_props) then
+        allocate(ty_optical_props_2str::aer_props,__STAT__)
+        TEST_(aer_props%init(k_dist%get_band_lims_wavenumber()))
+      end if
+
+      ! ty_optical_props routines have an internal deallocation
+      select type (cloud_props_bnd_liq)
+        class is (ty_optical_props_2str)
+          TEST_(cloud_props_bnd_liq%alloc_2str(ncols_block,LM))
+      end select
+      select type (cloud_props_bnd_ice)
+        class is (ty_optical_props_2str)
+          TEST_(cloud_props_bnd_ice%alloc_2str(ncols_block,LM))
+      end select
+      select type (cloud_props_gpt_liq)
+        class is (ty_optical_props_2str)
+          TEST_(cloud_props_gpt_liq%alloc_2str(ncols_block,LM))
+      end select
+      select type (cloud_props_gpt_ice)
+        class is (ty_optical_props_2str)
+          TEST_(cloud_props_gpt_ice%alloc_2str(ncols_block,LM))
+      end select
+      if (need_aer_optical_props) then
+        select type (aer_props)
+          class is (ty_optical_props_2str)
+            TEST_(aer_props%alloc_2str(ncols_block,LM))
+        end select
+      end if
+      select type (optical_props)
+        class is (ty_optical_props_1scl)
+          TEST_(optical_props%alloc_1scl(ncols_block,LM))
+        class is (ty_optical_props_2str)
+          TEST_(optical_props%alloc_2str(ncols_block,LM))
+        class is (ty_optical_props_nstr)
+          TEST_(optical_props%alloc_nstr(nmom,ncols_block,LM))
+      end select
+
+      call compute_gas_optics(colS, colE, ncols_block, LM, &
+        gas_concs, k_dist, p_lay, p_lev, t_lay, &
+        optical_props, toa_flux, MAPL, __RC__)
+
+      call compute_aer_optics(colS, colE, need_aer_optical_props, &
+        taua, ssaa, asya, aer_props, __RC__)
+
+      call compute_cloud_optics_mcica( &
+        colS, colE, ncols_block, LM, ngpt, &
+        gen_mro, cond_inhomo, cloud_overlap_type, cwp_fac_arg, IM_World, &
+        seeds_time_key, &
+        QQ3, RR3, dp_wp, dummy_wp, CL, dzmid, adl, rdl, Ig1D, Jg1D, &
+        cloud_optics, &
+        cloud_props_bnd_liq, cloud_props_bnd_ice, &
+        cloud_props_gpt_liq, cloud_props_gpt_ice, &
+        cld_mask, &
+        MAPL, __RC__)
+
+      ! REFRESH super-layer diagnostics (before delta-scaling TAUs).
+      ! ** Calculated from subcolumn ensemble, so stochastic **
+      ! -------------------------------------------------------
+      call compute_sprlyr_diags_predelta( &
+        colS, ncols_block, LM, ngpt, nbnd, LCLDLM, LCLDMH, &
+        include_aerosols, &
+        cld_mask, ClearCounts, CL, toa_flux, band_lims_gpt, &
+        cloud_props_gpt_liq, cloud_props_gpt_ice, &
+        CLDTS, CLDHS, CLDMS, CLDLS, &
+        COTTP, COTHP, COTMP, COTLP, &
+        COTDTP, COTDHP, COTDMP, COTDLP, &
+        COTNTP, COTNHP, COTNMP, COTNLP, &
+#ifdef SOLAR_RADVAL
+        TAUTP, TAUHP, TAUMP, TAULP, &
+        COTLDTP, COTLDHP, COTLDMP, COTLDLP, &
+        COTLNTP, COTLNHP, COTLNMP, COTLNLP, &
+        COTIDTP, COTIDHP, COTIDMP, COTIDLP, &
+        COTINTP, COTINHP, COTINMP, COTINLP, &
+        SSALDTP, SSALDHP, SSALDMP, SSALDLP, &
+        SSALNTP, SSALNHP, SSALNMP, SSALNLP, &
+        SSAIDTP, SSAIDHP, SSAIDMP, SSAIDLP, &
+        SSAINTP, SSAINHP, SSAINMP, SSAINLP, &
+        ASMLDTP, ASMLDHP, ASMLDMP, ASMLDLP, &
+        ASMLNTP, ASMLNHP, ASMLNMP, ASMLNLP, &
+        ASMIDTP, ASMIDHP, ASMIDMP, ASMIDLP, &
+        ASMINTP, ASMINHP, ASMINMP, ASMINLP, &
+#endif
+        MAPL, __RC__)
+
+      ! delta-scaling of cloud optical properties (accounts for forward scattering)
+      call compute_delta_scale( &
+        colS, ncols_block, LM, ngpt, nbnd, &
+        rrtmgp_delta_scale, rrtmgp_use_rrtmg_iceflg3_like_forwice, &
+        CL, RR3, band_lims_gpt, &
+        cloud_optics, cloud_props_gpt_liq, cloud_props_gpt_ice, &
+        forwliq, forwice, &
+        MAPL, __RC__)
+
+#ifdef SOLAR_RADVAL
+      ! REFRESH super-layer diagnostics (after delta-scaling TAUs).
+      ! ** Calculated from subcolumn ensemble, so stochastic **
+      ! -------------------------------------------------------
+      call compute_sprlyr_diags_postdelta( &
+        colS, ncols_block, LM, ngpt, nbnd, LCLDLM, LCLDMH, &
+        include_aerosols, &
+        CL, toa_flux, band_lims_gpt, &
+        forwliq, forwice, &
+        cloud_props_gpt_liq, cloud_props_gpt_ice, &
+        CDSDTP, CDSDHP, CDSDMP, CDSDLP, &
+        CDSNTP, CDSNHP, CDSNMP, CDSNLP, &
+        CDSLDTP, CDSLDHP, CDSLDMP, CDSLDLP, &
+        CDSLNTP, CDSLNHP, CDSLNMP, CDSLNLP, &
+        CDSIDTP, CDSIDHP, CDSIDMP, CDSIDLP, &
+        CDSINTP, CDSINHP, CDSINMP, CDSINLP, &
+        SDSLDTP, SDSLDHP, SDSLDMP, SDSLDLP, &
+        SDSLNTP, SDSLNHP, SDSLNMP, SDSLNLP, &
+        SDSIDTP, SDSIDHP, SDSIDMP, SDSIDLP, &
+        SDSINTP, SDSINHP, SDSINMP, SDSINLP, &
+        ADSLDTP, ADSLDHP, ADSLDMP, ADSLDLP, &
+        ADSLNTP, ADSLNHP, ADSLNMP, ADSLNLP, &
+        ADSIDTP, ADSIDHP, ADSIDMP, ADSIDLP, &
+        ADSINTP, ADSINHP, ADSINMP, ADSINLP, &
+        FORLDTP, FORLDHP, FORLDMP, FORLDLP, &
+        FORLNTP, FORLNHP, FORLNMP, FORLNLP, &
+        FORIDTP, FORIDHP, FORIDMP, FORIDLP, &
+        FORINTP, FORINHP, FORINMP, FORINLP, &
+        MAPL, __RC__)
+#endif
+
+      call compute_rte_sw( &
+        colS, colE, ngpt, &
+        tsi, toa_flux, need_aer_optical_props, aer_props, optical_props, &
+        top_at_1, mu0, sfc_alb_dir, sfc_alb_dif, &
+        fluxes_clrsky, flux_up_clrsky(colS:colE,:), flux_net_clrsky(colS:colE,:), &
+        fluxes_allsky, flux_up_allsky(colS:colE,:), flux_net_allsky(colS:colE,:), &
+        bnd_flux_dn_allsky(colS:colE,:,:), bnd_flux_dir_allsky(colS:colE,:,:), &
+        bnd_flux_net_allsky(colS:colE,:,:), &
+        cloud_props_gpt_liq, cloud_props_gpt_ice, &
+        MAPL, __RC__)
+
+      ! deallocate per-block arrays
+      deallocate(toa_flux,      __STAT__)
+      deallocate(cld_mask,      __STAT__)
+      deallocate(forwliq,       __STAT__)
+      deallocate(forwice,       __STAT__)
+      if (include_aerosols) &
+        deallocate(ClearCounts, __STAT__)
+      ! cloud_props_*, aer_props, optical_props are local allocatables;
+      ! they are automatically finalized/deallocated on return.
+
+    end subroutine PROCESS_RRTMGP_BLOCK
 #undef TEST_
 
 

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -5364,44 +5364,15 @@ contains
           MAPL, __RC__)
 #endif
 
-        call MAPL_TimerOn(MAPL,"--RRTMGP_RT",__RC__)
-
-        ! scale to our tsi
-        ! (both toa_flux and tsi are NORMAL to solar beam, [W/m2])
-        toa_flux = toa_flux * spread(tsi(colS:colE)/sum(toa_flux,dim=2), 2, ngpt)
-
-        ! add in aerosol optical properties if requested and available
-        if (need_aer_optical_props) then
-          TEST_(aer_props%increment(optical_props))
-        end if
-
-        ! clear-sky radiative transfer
-        fluxes_clrsky%flux_up  => flux_up_clrsky(colS:colE,:)
-        fluxes_clrsky%flux_net => flux_net_clrsky(colS:colE,:)
-        error_msg = rte_sw( &
-          optical_props, top_at_1, mu0(colS:colE), toa_flux, &
-          sfc_alb_dir(:,colS:colE), sfc_alb_dif(:,colS:colE), &
-          fluxes_clrsky)
-        TEST_(error_msg)
-
-        ! add in cloud optical properties
-        ! add ice first since its optical depths are usually smaller
-        TEST_(cloud_props_gpt_ice%increment(optical_props))
-        TEST_(cloud_props_gpt_liq%increment(optical_props))
-
-        ! all-sky radiative transfer
-        fluxes_allsky%flux_up         => flux_up_allsky(colS:colE,:)
-        fluxes_allsky%flux_net        => flux_net_allsky(colS:colE,:)
-        fluxes_allsky%bnd_flux_dn     => bnd_flux_dn_allsky(colS:colE,:,:)
-        fluxes_allsky%bnd_flux_dn_dir => bnd_flux_dir_allsky(colS:colE,:,:)
-        fluxes_allsky%bnd_flux_net    => bnd_flux_net_allsky(colS:colE,:,:)
-        error_msg = rte_sw( &
-          optical_props, top_at_1, mu0(colS:colE), toa_flux, &
-          sfc_alb_dir(:,colS:colE), sfc_alb_dif(:,colS:colE), &
-          fluxes_allsky)
-        TEST_(error_msg)
-
-        call MAPL_TimerOff(MAPL,"--RRTMGP_RT",__RC__)
+        call compute_rte_sw( &
+          colS, colE, ngpt, &
+          tsi, toa_flux, need_aer_optical_props, aer_props, optical_props, &
+          top_at_1, mu0, sfc_alb_dir, sfc_alb_dif, &
+          fluxes_clrsky, flux_up_clrsky, flux_net_clrsky, &
+          fluxes_allsky, flux_up_allsky, flux_net_allsky, &
+          bnd_flux_dn_allsky, bnd_flux_dir_allsky, bnd_flux_net_allsky, &
+          cloud_props_gpt_liq, cloud_props_gpt_ice, &
+          MAPL, __RC__)
 
         ! deallocate per-block arrays
         ! Note: urand*, alpha, rcorr, zcw are now local to compute_cloud_optics_mcica.
@@ -7266,6 +7237,92 @@ contains
       RETURN_(ESMF_SUCCESS)
 
     end subroutine compute_sprlyr_diags_postdelta
+#undef TEST_
+
+#define TEST_(A) error_msg = A; if (trim(error_msg)/="") then; _FAIL("RRTMGP Error: "//trim(error_msg)); endif
+    subroutine compute_rte_sw( &
+        colS, colE, ngpt, &
+        tsi, toa_flux, need_aer_optical_props, aer_props, optical_props, &
+        top_at_1, mu0, sfc_alb_dir, sfc_alb_dif, &
+        fluxes_clrsky, flux_up_clrsky, flux_net_clrsky, &
+        fluxes_allsky, flux_up_allsky, flux_net_allsky, &
+        bnd_flux_dn_allsky, bnd_flux_dir_allsky, bnd_flux_net_allsky, &
+        cloud_props_gpt_liq, cloud_props_gpt_ice, &
+        MAPL, RC)
+
+      use mo_optical_props,   only: ty_optical_props_arry
+      use mo_rte_kind,        only: wp
+      use mo_rte_sw,          only: rte_sw
+      use mo_fluxes_byband,   only: ty_fluxes_byband
+
+      integer,                              intent(in)    :: colS, colE, ngpt
+      real(wp),                             intent(in)    :: tsi(:)
+      real(wp),                             intent(inout) :: toa_flux(:,:)
+      logical,                              intent(in)    :: need_aer_optical_props
+      class(ty_optical_props_arry),         intent(inout) :: aer_props
+      class(ty_optical_props_arry),         intent(inout) :: optical_props
+      logical,                              intent(in)    :: top_at_1
+      real(wp),                             intent(in)    :: mu0(:)
+      real(wp),                             intent(in)    :: sfc_alb_dir(:,:)
+      real(wp),                             intent(in)    :: sfc_alb_dif(:,:)
+      type(ty_fluxes_byband),               intent(inout) :: fluxes_clrsky
+      real(wp),              target,        intent(inout) :: flux_up_clrsky(:,:)
+      real(wp),              target,        intent(inout) :: flux_net_clrsky(:,:)
+      type(ty_fluxes_byband),               intent(inout) :: fluxes_allsky
+      real(wp),              target,        intent(inout) :: flux_up_allsky(:,:)
+      real(wp),              target,        intent(inout) :: flux_net_allsky(:,:)
+      real(wp),              target,        intent(inout) :: bnd_flux_dn_allsky(:,:,:)
+      real(wp),              target,        intent(inout) :: bnd_flux_dir_allsky(:,:,:)
+      real(wp),              target,        intent(inout) :: bnd_flux_net_allsky(:,:,:)
+      class(ty_optical_props_arry),         intent(inout) :: cloud_props_gpt_liq
+      class(ty_optical_props_arry),         intent(inout) :: cloud_props_gpt_ice
+      type(MAPL_MetaComp),                  intent(inout) :: MAPL
+      integer,               optional,      intent(out)   :: RC
+
+      character(len=512) :: error_msg
+      integer            :: STATUS
+
+      call MAPL_TimerOn(MAPL,"--RRTMGP_RT",__RC__)
+
+      ! scale to our tsi
+      ! (both toa_flux and tsi are NORMAL to solar beam, [W/m2])
+      toa_flux = toa_flux * spread(tsi(colS:colE)/sum(toa_flux,dim=2), 2, ngpt)
+
+      ! add in aerosol optical properties if requested and available
+      if (need_aer_optical_props) then
+        TEST_(aer_props%increment(optical_props))
+      end if
+
+      ! clear-sky radiative transfer
+      fluxes_clrsky%flux_up  => flux_up_clrsky
+      fluxes_clrsky%flux_net => flux_net_clrsky
+      error_msg = rte_sw( &
+        optical_props, top_at_1, mu0(colS:colE), toa_flux, &
+        sfc_alb_dir(:,colS:colE), sfc_alb_dif(:,colS:colE), &
+        fluxes_clrsky)
+      TEST_(error_msg)
+
+      ! add in cloud optical properties
+      ! add ice first since its optical depths are usually smaller
+      TEST_(cloud_props_gpt_ice%increment(optical_props))
+      TEST_(cloud_props_gpt_liq%increment(optical_props))
+
+      ! all-sky radiative transfer
+      fluxes_allsky%flux_up         => flux_up_allsky
+      fluxes_allsky%flux_net        => flux_net_allsky
+      fluxes_allsky%bnd_flux_dn     => bnd_flux_dn_allsky
+      fluxes_allsky%bnd_flux_dn_dir => bnd_flux_dir_allsky
+      fluxes_allsky%bnd_flux_net    => bnd_flux_net_allsky
+      error_msg = rte_sw( &
+        optical_props, top_at_1, mu0(colS:colE), toa_flux, &
+        sfc_alb_dir(:,colS:colE), sfc_alb_dif(:,colS:colE), &
+        fluxes_allsky)
+      TEST_(error_msg)
+
+      call MAPL_TimerOff(MAPL,"--RRTMGP_RT",__RC__)
+
+      RETURN
+    end subroutine compute_rte_sw
 #undef TEST_
 
 

--- a/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
+++ b/GEOSsolar_GridComp/GEOS_SolarGridComp.F90
@@ -5288,15 +5288,9 @@ contains
           class is (ty_optical_props_nstr)
             TEST_(optical_props%alloc_nstr(nmom,ncols_block,LM))
         end select
-        TEST_(gas_concs%get_subset(colS,ncols_block,gas_concs_block))
-
-        call MAPL_TimerOn(MAPL,"--RRTMGP_GAS_OPTICS",__RC__)
-        ! gas optics, including source functions
-        error_msg = k_dist%gas_optics( &
-          p_lay(colS:colE,:), p_lev(colS:colE,:), t_lay(colS:colE,:), &
-          gas_concs_block, optical_props, toa_flux)
-        TEST_(error_msg)
-        call MAPL_TimerOff(MAPL,"--RRTMGP_GAS_OPTICS",__RC__)
+        call compute_gas_optics(colS, colE, ncols_block, LM, &
+          gas_concs, k_dist, p_lay, p_lev, t_lay, &
+          optical_props, toa_flux, MAPL, __RC__)
 
         ! get block of aerosol optical props
         if (need_aer_optical_props) then
@@ -6852,7 +6846,53 @@ contains
       call MAPL_TimerOff(MAPL,"-BALANCE")
 
       RETURN_(ESMF_SUCCESS)
+
     end subroutine SORADCORE
+
+    ! ---------------------------------------------------------------------------
+    ! Compute gas optical properties for one block of columns.
+    ! gas_concs_block and error_msg are local (thread-private in future OMP use).
+    ! ---------------------------------------------------------------------------
+#define TEST_(A) error_msg = A; if (trim(error_msg)/="") then; _FAIL("RRTMGP Error: "//trim(error_msg)); endif
+    subroutine compute_gas_optics(colS, colE, ncols_block, LM, &
+        gas_concs, k_dist, p_lay, p_lev, t_lay, &
+        optical_props, toa_flux, MAPL, RC)
+
+      use mo_gas_concentrations, only: ty_gas_concs
+      use mo_gas_optics_rrtmgp,  only: ty_gas_optics_rrtmgp
+      use mo_optical_props,      only: ty_optical_props_arry
+      use mo_rte_kind,           only: wp
+
+      integer,                           intent(in)    :: colS, colE, ncols_block, LM
+      type(ty_gas_concs),                intent(in)    :: gas_concs
+      type(ty_gas_optics_rrtmgp),        intent(in)    :: k_dist
+      real(wp),                          intent(in)    :: p_lay(:,:), p_lev(:,:), t_lay(:,:)
+      class(ty_optical_props_arry),      intent(inout) :: optical_props
+      real(wp),                          intent(out)   :: toa_flux(:,:)
+      type(MAPL_MetaComp),               intent(inout) :: MAPL
+      integer, optional,                 intent(out)   :: RC
+
+      ! locals -- will be thread-private under future !$OMP PARALLEL DO
+      type(ty_gas_concs)         :: gas_concs_block
+      character(len=ESMF_MAXSTR) :: error_msg
+      integer                    :: STATUS
+
+      call MAPL_TimerOn(MAPL,"--RRTMGP_GAS_OPTICS",__RC__)
+
+      TEST_(gas_concs%get_subset(colS, ncols_block, gas_concs_block))
+
+      ! gas optics, including source functions
+      error_msg = k_dist%gas_optics( &
+        p_lay(colS:colE,:), p_lev(colS:colE,:), t_lay(colS:colE,:), &
+        gas_concs_block, optical_props, toa_flux)
+      TEST_(error_msg)
+
+      call MAPL_TimerOff(MAPL,"--RRTMGP_GAS_OPTICS",__RC__)
+
+      RETURN_(ESMF_SUCCESS)
+
+    end subroutine compute_gas_optics
+#undef TEST_
 
 
     subroutine SHRTWAVE(PLhPa,TA,WA,OA,CO2,COSZ   , &


### PR DESCRIPTION
# PR Notes: OpenMP in GEOS_SolarGridComp

**GH Issue:** GEOS-ESM/GEOSgcm_GridComp#1387  
**Branch:** `feature/tclune/solar_openmp` (in `GEOSradiation_GridComp`)  
**File:** `GEOSsolar_GridComp/GEOS_SolarGridComp.F90`

---

## Summary

This PR adds OpenMP thread-level parallelism to the RRTMGP shortwave radiation
block loop in `SORADCORE`. The work was split into separate commits, each of
which is expected to compile cleanly and (for the earlier steps) to produce
bit-identical results with the baseline. This structure is intentional: it allows
`git bisect` to pinpoint any regression introduced along the way.

### Steps and commits

| Commit | Step | Description |
|---|---|---|
| `31a06db` | 1 | Uniform per-block alloc/dealloc — prerequisite cleanup |
| `67eab50` | 2a | Extract `compute_gas_optics` |
| `ea71b08` | 2b | Extract `compute_aer_optics` |
| `df4f377` | 2c | Extract `compute_cloud_optics_mcica` |
| `7b48629` | 2d | Extract `compute_sprlyr_diags_predelta` |
| `b12e93c` | 2e | Extract `compute_delta_scale` |
| `d3e9d03` | 2f | Extract `compute_sprlyr_diags_postdelta` |
| `835c814` | 2g | Extract `compute_rte_sw` |
| `e3bd356` | 3 | Assemble `PROCESS_RRTMGP_BLOCK` wrapper (all per-block state moved to locals) |
| `9fc54cc` | 4 | Add `!$OMP PARALLEL DO SCHEDULE(DYNAMIC)` over block loop |

Steps 1–3 are pure refactoring: no algorithmic change, results should be
bit-identical. Step 4 introduces the OpenMP parallelism; results may differ from
the baseline due to floating-point non-associativity across threads (the McICA
sampling is stochastic per block, so per-run variance already exists).

### Known limitation

MAPL sub-phase timers (`--RRTMGP_GAS_OPTICS`, `--RRTMGP_CLOUD_OPTICS`, etc.)
inside the parallel region are commented out — MAPL's profiler is not
thread-safe. Outer timers around the full RRTMGP section are unaffected.
Restoring sub-phase timing is left as future work.

### Future work (Step 5)

The `PROCESS_RRTMGP_BLOCK` argument list is long (~60 args). A follow-up will
introduce a context derived type to reduce this.

---

## Key Assumption

RRTMGP library routines (`rte_sw`, gas/cloud optics kernels, etc.) are assumed
**thread-safe**. Confirmed by RRTMGP developers. No locking around RRTMGP calls
is therefore required.

---

## Architecture Decision: Module-level extracted subroutines

All extracted `compute_*` subroutines are placed at **module level** (inside the
`RUN contains` block, as siblings of `SORADCORE`), not nested inside `SORADCORE`.

Rationale:
- Fortran does not permit a `contains` block inside an internal subroutine
  (`SORADCORE` is itself already contained inside `RUN`).
- Module-level placement gives the compiler a full explicit interface at every
  call site, which is required for polymorphic (`class`) dummy arguments.
- No host association: each subroutine is fully self-contained with its own
  `STATUS` local and explicit dummy arguments. This is essential for correct
  OpenMP behaviour in Step 4.

---

## Macro conventions

`TEST_` is `#define`d inside `SORADCORE` (line ~4840) and `#undef`d before the
new subroutines' location in the file. Each extracted subroutine therefore
brackets itself with its own `#define TEST_` / `#undef TEST_` pair.

`STATUS` and `RC` are declared locally in each extracted subroutine (not
host-associated), so each subroutine's error handling is fully independent.

---

## Step 1 — Uniform per-block alloc/dealloc

**What changed:**
- Replaced the two-phase `nBlocks` computation (integer division of full blocks,
  then optional `+1` for a partial block) with a single ceiling-division:
  `nBlocks = (ncol + rrtmgp_blockSize - 1) / rrtmgp_blockSize`
- Removed `partial_block` and `partial_blockSize` variables.
- Moved all per-block allocations to the top of the loop, sized to
  `ncols_block = min(rrtmgp_blockSize, ncol - (b-1)*rrtmgp_blockSize)`.
- Added symmetric deallocations at the bottom of each iteration.
- Removed the in-loop `if (b == nBlocks .and. partial_block)` dealloc/realloc
  block entirely — this was the main source of non-uniformity across iterations.
- Simplified `urand(:,:,1:ncols_block)` slices to plain `urand` now that the
  array is allocated to exactly `ncols_block` columns.

**Why:** Every iteration is now structurally identical, which is a prerequisite
for clean subroutine extraction and for `!$OMP PARALLEL DO`.

---

## Step 2a — Extract `compute_gas_optics`

**What moved in:** `gas_concs%get_subset` + `k_dist%gas_optics` + surrounding
timers.

**Becomes local (thread-private in future OMP):** `gas_concs_block`, `error_msg`.

**Note:** `LM` is in the argument list but not directly used inside the
subroutine body (array shapes are inferred). Retained for documentation clarity;
can be removed if the compiler warns.

---

## Step 2b — Extract `compute_aer_optics`

**What moved in:** Loading and normalizing aerosol optical properties
(`taua/ssaa/asya` slices → `aer_props%tau/ssa/g`), renormalization, and
value clamping.

**Becomes local (thread-private in future OMP):** Only scalars (`error_msg`,
`STATUS`); `aer_props` itself is `intent(inout)` and will remain a shared
per-block object.

**Design notes:**
- The `need_aer_optical_props` guard (previously an outer `if` wrapping the
  whole block) is now an **early return** inside the subroutine. Slightly
  cleaner, and avoids passing `aer_props` as an unallocated dummy in the
  `intent(inout)` position when aerosols are not active.
- `taua/ssaa/asya` are declared as `real, pointer` in `SORADCORE` but passed
  as `real, dimension(:,:,:), intent(in)` assumed-shape dummy arguments. The
  pointer attribute is shed at the call boundary — correct Fortran.
- No `MAPL` argument needed (no timers in this subroutine).

---

## Step 2c — Extract `compute_cloud_optics_mcica`

**What moved in:** Cloud optical property computation (liquid and ice phases via
`cloud_optics%cloud_optics`), exponential inter-layer correlation coefficients
(`alpha`, `rcorr`), McICA random number generation (Philox PRNG seeding per
column via `Ig1D`/`Jg1D`), cloud mask sampling (`sampled_mask_max_ran`,
`sampled_urand_gen_max_ran`), sub-gridscale condensate scaling (`zcw`),
`draw_samples` band→gpoint expansion, and `zcw` scaling of cloud optical depths.
Encompasses both the `--RRTMGP_CLOUD_OPTICS` and `--RRTMGP_MCICA` timers.

**Becomes local (thread-private in future OMP):** `alpha`, `rcorr`, `zcw`,
`urand`, `urand_aux`, `urand_cond`, `urand_cond_aux`, `cld_mask`, `rng`,
`seeds`, `isub`, `icol`, `ilay`, `igpt`, `cld_frac`, `sigma_qcw`,
`error_msg`, `STATUS`.

**Design notes:**
- `seeds` in the original code has two levels of initialization: `seeds(2)` is
  computed once before the block loop from ESMF time; `seeds(1)` is set
  per-column inside the loop from `Ig1D`/`Jg1D`. The subroutine receives
  `seeds_time_key` (an `integer, intent(in)`) carrying `seeds(2)`, allocates
  a local `seeds(3)` array, and sets `seeds(2) = seeds_time_key` before the
  per-column PRNG loop. `seeds(3) = 65536` (SW counter convention) is also
  set locally. The outer `seeds` array in `SORADCORE` is retained only for
  this purpose and is still deallocated in the post-loop cleanup.
- `cld_mask` is needed by subsequent steps (SPRLYR_DIAGS, RTE_SW) and therefore
  cannot be a purely local variable. It is declared `logical, allocatable,
  intent(out) :: cld_mask(:,:,:)` — allocated inside the subroutine and
  returned to the caller, which deallocates it at the end of each block
  iteration as before.
- All other per-block allocatables (`urand*`, `alpha`, `rcorr`, `zcw`) are
  purely local to the subroutine and freed automatically on return.
- `cloud_overlap_type` is passed as `character(len=*)` assumed-length dummy.
- `QQ3`, `RR3`, `CL` are `real` (default precision) pointer arrays in
  `SORADCORE`; passed as assumed-shape `intent(in)` dummies (pointer attribute
  shed at call boundary).
- `dp_wp`, `dummy_wp`, `dzmid` are `real(wp)` allocatables; passed as
  assumed-shape `intent(in)`.
- `adl`, `rdl`, `Ig1D`, `Jg1D` are `real` pointer arrays; passed as
  assumed-shape `intent(in)`.
- `cloud_optics` is `intent(inout)` because `get_min/max_radius_*` are
  potentially non-pure methods on the object.
- Both `--RRTMGP_CLOUD_OPTICS` and `--RRTMGP_MCICA` timers are fully inside
  the subroutine (TimerOn and TimerOff paired within the subroutine body).

**Bugs found and fixed during this step (not pre-existing):**
- Initial insertion had `seeds` allocated as size 4 (should be 3) and did not
  set `seeds(2)` from the ESMF time value — would have produced wrong random
  numbers. Fixed by adding `seeds_time_key` argument.
- `MAPL_TimerOff("--RRTMGP_MCICA")` was left at the call site while
  `TimerOn` was inside the subroutine — mismatched pair. Moved `TimerOff`
  inside the subroutine.
- `cld_mask` was allocated both in the outer loop and inside the subroutine
  (as a local). Fixed by making it `intent(out)` and removing the outer
  per-iteration `allocate(cld_mask,...)`.
- `urand`, `urand_aux`, `urand_cond`, `urand_cond_aux`, `alpha`, `rcorr`,
  `zcw` per-iteration alloc/dealloc left in the outer loop after being moved
  into the subroutine. Removed.
- Stale post-loop `deallocate(seeds,urand,cld_mask,...)` and
  `deallocate(adl,alpha,urand_aux,...)` cleaned up — only `seeds`, `adl`,
  `rdl` remain at that scope.
- Stale post-loop `deallocate(toa_flux,...)` and
  `deallocate(ClearCounts,...)` removed (both are per-iteration allocatables
  already freed in the block loop).
- Duplicate `allocate(cld_mask,...)` inside the subroutine (once before the
  `gen_mro` block, once after) — removed the second one.


---

## Step 2d — Extract `compute_sprlyr_diags_predelta`

**What moved in:** Super-layer cloud fraction diagnostics (`CLDTS/HS/MS/LS` via
`clearCounts_threeBand`) and in-cloud optical depth diagnostics in the PAR
super-band (`COTx`, `SSAx`, `ASMx`, and under `#ifdef SOLAR_RADVAL` the `TAUx`
variants), computed from the McICA subcolumn ensemble **before** delta-scaling.
Encompasses the `--RRTMGP_SPRLYR_DIAGS` timer (first occurrence).

**Becomes local (thread-private in future OMP):** `isub`, `icol`, `ib`, `igpt`,
`wgt`, `stau*/sltau*/sitau*` scalars, `sltaussa*/sitaussa*/sltaussag*/sitaussag*`
scalars (under `SOLAR_RADVAL`), `error_msg`, `STATUS`.

**Design notes:**
- All EXPORT pointer arrays (`CLDTS`, `COTTP`, etc.) are passed as
  assumed-shape `intent(inout)` dummies — pointer attribute shed at call
  boundary, correct Fortran.
- `ClearCounts` is `intent(inout)` (output of `clearCounts_threeBand`).
- `cloud_props_gpt_liq/ice` are `class(ty_optical_props_arry), intent(in)`;
  `ty_optical_props_2str` also `use`d so `select type` inside works.
- `wp` is `use`d explicitly for `toa_flux(:,:)` dummy type.
- `#define TEST_` uses the RRTMGP `error_msg` form for consistency; `error_msg`
  is declared locally and consumed only by `__RC__` expansion of timer calls.

**Bug found during compile:** Initial dummy declaration had `ClearCounts` as
`real` — incorrect. `clearCounts_threeBand` declares it `integer, intent(out)`.
`ClearCounts` in SORADCORE is also `integer` (declared elsewhere in the file,
not found by initial search). Fixed to `integer, intent(inout)`. Lesson: always
verify dummy types against the actual SORADCORE declaration, not by inference.

---

## Step 2e — Extract `compute_delta_scale`

**What moved in:** Delta-scaling of cloud optical properties for liquid
(`forwliq = g**2` then `delta_scale`) and ice (either RRTMG iceflag==3-like
per-column/band/gpt interpolation using `fdlice3_rrtmgp`, or default `g**2`),
guarded by `rrtmgp_delta_scale` and `rrtmgp_use_rrtmg_iceflg3_like_forwice`.
Encompasses the `--RRTMGP_DELTA_SCALE` timer.

**Becomes local (thread-private in future OMP):** `isub`, `icol`, `ilay`, `ib`,
`igpt`, `radidx`, `radice_lwr`, `radice_upr`, `radice`, `radfac`, `rfint`,
`fdelta`, `error_msg`, `STATUS`.

**Design notes:**
- `forwliq` and `forwice` are `intent(out)` — initialized to zero inside the
  subroutine and returned for use in Step 2f (post-delta SPRLYR_DIAGS).
- `fdlice3_rrtmgp` is a module-level `parameter` — available via host
  association, not passed as an argument.
- `cloud_optics` is `intent(inout)` for `get_min/max_radius_ice()`.
- `cloud_props_gpt_liq/ice` are `intent(inout)` — `delta_scale()` modifies them.
- Types verified against SORADCORE declarations before writing.

---

## Step 2f — Extract `compute_sprlyr_diags_postdelta`

**What moved in:** Super-layer cloud optical depth diagnostics **after**
delta-scaling (`CDSx`, `SDSx`, `ADSx`, `FORx` arrays), computed from the McICA
subcolumn ensemble. Entire block is inside `#ifdef SOLAR_RADVAL` — both the call
site and the subroutine signature use this guard. Encompasses the second
occurrence of the `--RRTMGP_SPRLYR_DIAGS` timer.

**Becomes local (thread-private in future OMP):** `isub`, `icol`, `ib`, `igpt`,
`wgt`, `sltaussa*/sitaussa*/sltaussag*/sitaussag*/sltaussaf*/sitaussaf*` scalars,
`error_msg`, `STATUS`.

**Design notes:**
- `forwliq` and `forwice` are `intent(in)` (computed in Step 2e).
- `cloud_props_gpt_liq/ice` are `intent(in)` (delta-scaled in Step 2e, read-only here).
- All `CDSx`, `SDSx`, `ADSx`, `FORx` EXPORT arrays passed as assumed-shape
  `intent(inout)` dummies.

---

## Step 2g — Extract `compute_rte_sw`

**What moved in:** TSI scaling of `toa_flux`, optional aerosol increment into
`optical_props`, clear-sky `rte_sw` call (with `fluxes_clrsky` pointer setup),
cloud increment into `optical_props`, all-sky `rte_sw` call (with `fluxes_allsky`
pointer setup). Encompasses the `--RRTMGP_RT` timer.

**Becomes local (thread-private in OMP):** `fluxes_clrsky`, `fluxes_allsky`,
`error_msg`, `STATUS`.

**Design notes:**
- The flux arrays (`flux_up_clrsky`, `flux_net_clrsky`, etc.) are passed as
  block-sized slices (e.g. `flux_up_clrsky(colS:colE,:)`) from
  `PROCESS_RRTMGP_BLOCK`, so inside the subroutine the pointer assignments
  `fluxes_clrsky%flux_up => flux_up_clrsky` point directly to the right slice.
- `fluxes_clrsky`/`fluxes_allsky` are `type(ty_fluxes_byband)` local variables;
  their pointer components are set and consumed entirely within this subroutine.
- `MAPL` dummy is `type(MAPL_MetaComp), intent(inout)` — no `pointer` attribute,
  no `use MAPL_Mod` (available via host association). Consistent with all other
  extracted subroutines.

**Bug found during compile:** Initial version had `use MAPL_Mod` and
`type(MAPL_MetaComp), pointer` on the MAPL dummy — caused an ambiguous reference
error. Fixed by removing `use MAPL_Mod` (host association) and dropping `pointer`.

---

## Step 3 — Assemble `PROCESS_RRTMGP_BLOCK` wrapper

**What this does:** Wraps the entire per-block body into a single subroutine so
that `!$OMP PARALLEL DO` over `b = 1,nBlocks` is a one-liner at the call site.

**Per-block objects moved from SORADCORE to local variables in the wrapper:**
`optical_props`, `cloud_props_bnd_liq`, `cloud_props_bnd_ice`,
`cloud_props_gpt_liq`, `cloud_props_gpt_ice`, `aer_props`,
`fluxes_clrsky`, `fluxes_allsky`,
`toa_flux`, `cld_mask`, `forwliq`, `forwice`, `ClearCounts`,
`colS`, `colE`, `ncols_block`.

Each of these is now a private stack/heap variable per thread when the loop runs
under OpenMP.

**What stays in SORADCORE (shared):**
- All input data arrays (`p_lay`, `p_lev`, `t_lay`, `QQ3`, `RR3`, etc.)
- All EXPORT output arrays (indexed non-overlappingly by `colS:colE`)
- `cloud_optics`, `k_dist` (read-only after loading)
- `gas_concs`, `band_lims_gpt`, `tsi`, `mu0`, `sfc_alb_*`, etc.
- All scalar flags (`gen_mro`, `rrtmgp_delta_scale`, etc.)

**Init/finalize moved:** The `allocate`+`init` calls for `optical_props`,
`cloud_props_bnd/gpt_*`, and `aer_props` that were before the block loop in
SORADCORE are now inside `PROCESS_RRTMGP_BLOCK`. The corresponding `finalize()`
calls that were after the loop are removed — finalization is automatic when the
local allocatables go out of scope on return.

**`cwp_fac`:** This is a `real(wp), parameter` in SORADCORE, not accessible via
host association from a sibling module-level subroutine. Passed explicitly as
`cwp_fac_arg`.

**`cloud_optics` intent:** Declared `intent(inout)` (not `intent(in)`) because
`compute_cloud_optics_mcica` and `compute_delta_scale` call bound procedures on
it (`get_min/max_radius_*`, `cloud_optics%cloud_optics`). These do not actually
mutate stored data but Fortran requires `inout` to call non-pure bound procedures.
This means `cloud_optics` is technically a shared `inout` dummy in the OMP
parallel region — safe because RRTMGP is confirmed thread-safe and these methods
are read-only in practice.

**Argument list:** Very long (~60+ args). A future refactoring step (Step 5) will
introduce a context derived type to reduce this burden.

---

## Step 4 — Add `!$OMP PARALLEL DO`

**What changed:**
- Added `!$OMP PARALLEL DO SCHEDULE(DYNAMIC)` before `do b = 1,nBlocks`.
- Added `!$OMP END PARALLEL DO` after `end do`.
- All MAPL timer calls inside the extracted subroutines (14 total, covering
  `--RRTMGP_GAS_OPTICS`, `--RRTMGP_CLOUD_OPTICS`, `--RRTMGP_MCICA`,
  `--RRTMGP_SPRLYR_DIAGS` ×2, `--RRTMGP_DELTA_SCALE`, `--RRTMGP_RT`) are
  **commented out**. MAPL's profiler is not thread-safe; these timers would
  deadlock or corrupt timer state under OpenMP.

**Thread safety rationale:**
- RRTMGP confirmed thread-safe by developers.
- All per-block state is private inside `PROCESS_RRTMGP_BLOCK` (local allocatables).
- Output arrays written only to non-overlapping `colS:colE` column ranges — no race.
- `cloud_optics` is shared `inout` but only read in practice (see Step 3 note).
- `SCHEDULE(DYNAMIC)` chosen because block sizes may differ (last block can be partial).

**Known limitation:** Sub-phase timing (gas optics, cloud optics, RT, etc.) is
lost while inside the OMP parallel region. A follow-up can either restore timing
via thread-local accumulators or accept the loss.

---

## Commit history (submodule `GEOSradiation_GridComp`, branch `feature/tclune/solar_openmp`)

| Commit | Step |
|---|---|
| `31a06db` | Step 1: uniform per-block alloc/dealloc |
| `67eab50` | Step 2a: extract `compute_gas_optics` |
| `ea71b08` | Step 2b: extract `compute_aer_optics` |
| `df4f377` | Step 2c: extract `compute_cloud_optics_mcica` |
| `7b48629` | Step 2d: extract `compute_sprlyr_diags_predelta` |
| `b12e93c` | Step 2e: extract `compute_delta_scale` |
| `d3e9d03` | Step 2f: extract `compute_sprlyr_diags_postdelta` |
| `835c814` | Step 2g: extract `compute_rte_sw` |
| `e3bd356` | Step 3: assemble `PROCESS_RRTMGP_BLOCK` |
| *(pending)* | Step 4: `!$OMP PARALLEL DO` |

---

## Future work (Step 5)

Introduce a context derived type to hold all the shared read-only inputs and
shared output arrays, replacing the ~60-argument list on `PROCESS_RRTMGP_BLOCK`
and its callees.